### PR TITLE
Debian's fix-format-codes patch

### DIFF
--- a/ureadseq.c
+++ b/ureadseq.c
@@ -1344,7 +1344,7 @@ short seqFileFormatFp(
     for (i=0; i < *skiplines; i++) ReadOneLine(sp);
     nlines= 0;
     ReadOneLine(sp);
-    sscanf( sp, "%d%d", &nspp, &nlen);
+    sscanf( sp, "%ld%ld", &nspp, &nlen);
     ReadOneLine(sp); /* 1st seq line */
     for (ps= sp+10, ilen=0; *ps!=0; ps++) if (isprint(*ps)) ilen++;
 
@@ -1590,7 +1590,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
   seqname[l] = 0;
 
   sscanf( seqname, "%30s", idword);
-  sprintf(numform, "%d", seqlen);
+  sprintf(numform, "%ld", seqlen);
   numwidth= strlen(numform)+1;
   nameform[0]= '\0';
 
@@ -1619,8 +1619,8 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
 
     case kOlsen:  /* Olsen seq. editor takes plain nucs OR Genbank  */
     case kGenBank:
-      fprintf(outf,"LOCUS       %s       %d bp\n", idword, seqlen);
-      fprintf(outf,"DEFINITION  %s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,"LOCUS       %s       %ld bp\n", idword, seqlen);
+      fprintf(outf,"DEFINITION  %s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
    /* fprintf(outf,"ACCESSION   %s\n", accnum); */
       fprintf(outf,"ORIGIN      \n");
       spacer = 11;
@@ -1634,7 +1634,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       /* somewhat like genbank... \\\*/
       /* fprintf(outf,"\\\\\\\n"); << only at top of file, not each entry... */
       fprintf(outf,"ENTRY           %s \n", idword);
-      fprintf(outf,"TITLE           %s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,"TITLE           %s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
    /* fprintf(outf,"ACCESSION       %s\n", accnum); */
       fprintf(outf,"SEQUENCE        \n");
       numwidth = 7;
@@ -1644,7 +1644,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       strcpy(endstr, "\n///");
       /* run a top number line for PIR */
       for (j=0; j<numwidth; j++) fputc(' ',outf);
-      for (j= 5; j<=width; j += 5) fprintf(outf,"%10d",j);
+      for (j= 5; j<=width; j += 5) fprintf(outf,"%10ld",j);
       fputc('\n',outf);
       linesout += 5;
       break;
@@ -1654,7 +1654,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
         fprintf(outf,">P1;%s\n", idword);
       else
         fprintf(outf,">DL;%s\n", idword);
-      fprintf(outf,"%s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,"%s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
       spacer = 11;
       strcpy(endstr,"*\n");
       linesout += 3;
@@ -1663,8 +1663,8 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
     case kEMBL:
       fprintf(outf,"ID   %s\n", idword);
   /*  fprintf(outf,"AC   %s\n", accnum); */
-      fprintf(outf,"DE   %s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
-      fprintf(outf,"SQ             %d BP\n", seqlen);
+      fprintf(outf,"DE   %s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,"SQ             %ld BP\n", seqlen);
       strcpy(endstr, "\n//"); /* 11Oct90: bug fix*/
       tab = 4;     /** added 31jan91 */
       spacer = 11; /** added 31jan91 */
@@ -1675,7 +1675,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
     case kGCG:
       fprintf(outf,"%s\n", seqname);
    /* fprintf(outf,"ACCESSION   %s\n", accnum); */
-      fprintf(outf,"    %s  Length: %d  (today)  Check: %d  ..\n", idword, seqlen, checksum);
+      fprintf(outf,"    %s  Length: %ld  (today)  Check: %lX  ..\n", idword, seqlen, checksum);
       spacer = 11;
       numleft = true;
       strcpy(endstr, "\n");  /* this is insurance to help prevent misreads at eof */
@@ -1684,13 +1684,13 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
 
     case kStrider: /* ?? map ?*/
       fprintf(outf,"; ### from DNA Strider ;-)\n");
-      fprintf(outf,"; DNA sequence  %s, %d bases, %X checksum.\n;\n", seqname, seqlen, checksum);
+      fprintf(outf,"; DNA sequence  %s, %ld bases, %lX checksum.\n;\n", seqname, seqlen, checksum);
       strcpy(endstr, "\n//");
       linesout += 3;
       break;
 
     case kFitch:
-      fprintf(outf,"%s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,"%s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
       spacer = 4;
       width = 60;
       linesout += 1;
@@ -1721,7 +1721,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       fprintf(outf,"    id { local id %d },\n", gPretty.atseq);
       fprintf(outf,"    descr { title \"%s\" },\n", seqid);
       fprintf(outf,"    inst {\n");
-      fprintf(outf,"      repr raw, mol %s, length %d, topology linear,\n", cp, seqlen);
+      fprintf(outf,"      repr raw, mol %s, length %ld, topology linear,\n", cp, seqlen);
       fprintf(outf,"      seq-data\n");
       if (seqtype == kAmino)
         fprintf(outf,"        iupacaa \"");
@@ -1743,7 +1743,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       tab  = 0; /* 1; */
       /* strcpy(endstr,";\nend;"); << this is end of all seqs.. */
       /* do a header comment line for paup */
-      fprintf(outf,"[Name: %-16s  Len:%6d  Check: %8X]\n", idword, seqlen, checksum);
+      fprintf(outf,"[Name: %-16s  Len:%6ld  Check: %8lX]\n", idword, seqlen, checksum);
       linesout += 1;
       break;
 
@@ -1760,13 +1760,13 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       tab  = gPretty.tab;
       /* also add rtf formatting w/ font, size, style */
       if (gPretty.nametop) {
-        fprintf(outf,"Name: %-16s  Len:%6d  Check: %8X\n", idword, seqlen, checksum);
+        fprintf(outf,"Name: %-16s  Len:%6ld  Check: %8lX\n", idword, seqlen, checksum);
         linesout++;
         }
       break;
 
     case kMSF:
-      fprintf(outf," Name: %-16s Len:%6d  Check: %5d  Weight:  1.00\n",
+      fprintf(outf," Name: %-16s Len:%6ld  Check: %5ld  Weight:  1.00\n",
                     idword, seqlen, checksum);
       linesout++;
       nameleft= true;
@@ -1778,7 +1778,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
       break;
 
     case kIG:
-      fprintf(outf,";%s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,";%s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
       fprintf(outf,"%s\n", idword);
       strcpy(endstr,"1"); /* == linear dna */
       linesout += 2;
@@ -1787,7 +1787,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
     default :
     case kZuker: /* don't attempt Zuker's ftn format */
     case kPearson:
-      fprintf(outf,">%s, %d bases, %X checksum.\n", seqname, seqlen, checksum);
+      fprintf(outf,">%s, %ld bases, %lX checksum.\n", seqname, seqlen, checksum);
       linesout += 1;
       break;
     }
@@ -1828,7 +1828,7 @@ short writeSeq(FILE *outf, const char *seq, const long seqlen,
         s[l++] = ' ';
         }
       if (l1 % 10 == 1 || l1 == width) {
-        if (numline==1) fprintf(outf,"%-9d ",i+1);
+        if (numline==1) fprintf(outf,"%-9ld ",i+1);
         s[l++]= '|'; /* == put a number here */
         }
       else s[l++]= ' ';


### PR DESCRIPTION
Description: Fix printf and scanf format codes to match the types actually passed
Author: Olly Betts <olly@survex.com>
Last-Update: 2014-06-08
Bug-Debian: http://bugs.debian.org/750906

This is mostly about longs being used, so %d -> %ld in the format strings.