### PR TITLE
wxWidgets3 transition to comply with runtime checks on wxEXPANDS flag

### DIFF
--- a/ABIviewer.cpp
+++ b/ABIviewer.cpp
@@ -280,14 +280,14 @@ void TABIviewer::initme ()
     wxBoxSizer *h3 = new wxBoxSizer ( wxHORIZONTAL ) ;
     wxBoxSizer *h4 = new wxBoxSizer ( wxHORIZONTAL ) ;
     
-    h1->Add ( aidLines , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h1->Add ( inv_compl , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h2->Add ( f_height , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h2->Add ( new wxStaticText ( this , -1 , txt("t_scale_height") ) , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h3->Add ( f_width , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h3->Add ( new wxStaticText ( this , -1 , txt("t_scale_width") ) , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;    
-    h4->Add ( slider , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
-    h4->Add ( new wxStaticText ( this , -1 , txt("t_zoom") ) , 0 , wxEXPAND|wxLEFT|wxRIGHT , 5 ) ;
+    h1->Add ( aidLines , 0 , wxEXPAND , 5 ) ;
+    h1->Add ( inv_compl , 0 , wxEXPAND , 5 ) ;
+    h2->Add ( f_height , 0 , wxEXPAND , 5 ) ;
+    h2->Add ( new wxStaticText ( this , -1 , txt("t_scale_height") ) , 0 , wxEXPAND , 5 ) ;
+    h3->Add ( f_width , 0 , wxEXPAND , 5 ) ;
+    h3->Add ( new wxStaticText ( this , -1 , txt("t_scale_width") ) , 0 , wxEXPAND , 5 ) ;    
+    h4->Add ( slider , 0 , wxEXPAND , 5 ) ;
+    h4->Add ( new wxStaticText ( this , -1 , txt("t_zoom") ) , 0 , wxEXPAND , 5 ) ;
 
 	v1->Add ( h1 , 1 ) ;
 	v1->Add ( h2 , 1 ) ;
@@ -300,7 +300,7 @@ void TABIviewer::initme ()
 
     wxBoxSizer *v0 = new wxBoxSizer ( wxVERTICAL ) ;
     v0->Add ( toolbar , 0 , wxBOTTOM , 5 ) ;
-    v0->Add ( h0 , 0 , wxBOTTOM|wxEXPAND , 5 ) ;
+    v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
     v0->Add ( sc , 1 , wxEXPAND ) ;
     SetSizer ( v0 ) ;
     v0->Fit ( this ) ;

--- a/Alignment.cpp
+++ b/Alignment.cpp
@@ -4,6 +4,7 @@
 #include "Alignment.h"
 #include "AlignmentAppearanceDialog.h"
 #include <wx/textfile.h>
+#include <wx/filename.h>
 
 #ifdef __DEBIAN__
 	#define USE_EXTERNAL_CLUSTALW
@@ -264,6 +265,7 @@ void TAlignment::initme ()
 	myapp()->frame->addTool ( toolBar , SEQ_PRINT ) ;
     if ( !myapp()->frame->mainToolBar ) toolBar->AddSeparator () ;
     toolBar->AddTool( ALIGNMENT_SETTINGS,
+                wxEmptyString,
                 myapp()->frame->bitmaps[21],
                 txt("t_alignment_settings") ) ;
     toolBar->AddSeparator () ;
@@ -304,7 +306,7 @@ void* TAlignment::Entry()
     wxString cwt = _T("clustalw.txt") ;
     wxString hd = myapp()->homedir ;
     
-    wxString tmpdir = wxGetTempFileName ( _T("") ) ;
+    wxString tmpdir = wxFileName::CreateTempFileName ( _T("") ) ;
     tmpdir.Replace ( _T("\\") , _T("/") ) ;
     tmpdir = tmpdir.BeforeLast ( '/' ) ;
     
@@ -437,7 +439,7 @@ void TAlignment::recalcAlignments ()
 		threadRunning = true ;
 		sc->Refresh () ;
 //		wxSafeYield() ;
-		wxThreadHelper::Create () ;
+		wxThreadHelper::CreateThread () ;
 		GetThread()->Run() ;
 		return ;
 	    }

--- a/AminoAcids.cpp
+++ b/AminoAcids.cpp
@@ -656,7 +656,7 @@ void TAminoAcids::handleListBox ( wxString t )
 		{
 		if ( curDisplay )
 			{
-			h1->Remove ( curDisplay ) ;
+			h1->Detach ( curDisplay ) ;
 			delete curDisplay ;
 			}
 		curDisplay = NULL ;

--- a/AminoAcids.cpp
+++ b/AminoAcids.cpp
@@ -602,14 +602,14 @@ void TAminoAcids::updateUndoMenu ()
     bool canUndo ;
     if ( lm.IsEmpty() )
         {
-        mi->SetText ( txt("u_no") ) ;
+        mi->SetItemLabel ( txt("u_no") ) ;
         mi->Enable ( false ) ;
 	canUndo = false ;
         }
     else
         {
         mi->Enable ( true ) ;
-        mi->SetText ( lm ) ;
+        mi->SetItemLabel ( lm ) ;
 	canUndo = true ;
         }
 #ifdef __WXMSW__

--- a/CGview.cpp
+++ b/CGview.cpp
@@ -41,10 +41,10 @@ CGdialog::CGdialog ( wxWindow *parent, const wxString& title , CGview *_p )
     
     width = new wxTextCtrl ( this , -1 , wxString::Format ( _T("%d") , p->width ) ) ;
     height = new wxTextCtrl ( this , -1 , wxString::Format ( _T("%d") , p->height ) ) ;
-    h1->Add ( new wxStaticText ( this , -1 , txt("t_cgview_image_dimensions") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( width , 1 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( new wxStaticText ( this , -1 , _T(" x ") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( height , 1 , wxEXPAND|wxALL , 5 ) ;
+    h1->Add ( new wxStaticText ( this , -1 , txt("t_cgview_image_dimensions") ) , 0 , wxEXPAND , 5 ) ;
+    h1->Add ( width , 1 , wxEXPAND , 5 ) ;
+    h1->Add ( new wxStaticText ( this , -1 , _T(" x ") ) , 0 , wxEXPAND , 5 ) ;
+    h1->Add ( height , 1 , wxEXPAND , 5 ) ;
     
     useDefaultColors = new wxCheckBox ( this , -1 , txt("t_cgview_use_default_colors") ) ;
     
@@ -52,22 +52,22 @@ CGdialog::CGdialog ( wxWindow *parent, const wxString& title , CGview *_p )
     runcgview = new wxCheckBox ( this , CGVIEW_RUN_CGVIEWER , txt("t_cgview_run_cgview") ) ;
     cgviewapp = new wxTextCtrl ( this , -1 , appname ) ;
     choosejar = new wxButton ( this , CGVIEW_CHOOSE_JAR , _T("..") ) ;
-    h3->Add ( runcgview , 0 , wxEXPAND|wxALL , 5 ) ;
-    h3->Add ( cgviewapp , 1 , wxEXPAND|wxALL , 5 ) ;
+    h3->Add ( runcgview , 0 , wxEXPAND , 5 ) ;
+    h3->Add ( cgviewapp , 1 , wxEXPAND , 5 ) ;
     h3->Add ( choosejar , 0 , wxALL , 5 ) ;
     
     runimageapp = new wxCheckBox ( this , -1 , txt("t_cgview_run_image_app") ) ;
     imagetypes = new wxChoice ( this , -1 ) ;
-    h4->Add ( new wxStaticText ( this , -1 , txt("t_cgview_imagetypes") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-    h4->Add ( imagetypes , 0 , wxEXPAND|wxALL , 5 ) ;
-    h4->Add ( runimageapp , 0 , wxEXPAND|wxALL , 5 ) ;
+    h4->Add ( new wxStaticText ( this , -1 , txt("t_cgview_imagetypes") ) , 0 , wxEXPAND , 5 ) ;
+    h4->Add ( imagetypes , 0 , wxEXPAND , 5 ) ;
+    h4->Add ( runimageapp , 0 , wxEXPAND , 5 ) ;
 
     showrestrictionsites = new wxCheckBox ( this , -1 , txt("t_cgview_showrestrictionsites") ) ;
     showgc = new wxCheckBox ( this , -1 , txt("t_cgview_showgc") ) ;
     wxButton *bgc = new wxButton ( this , CGVIEW_CHOOSE_BACKGROUND_COLOR , txt("t_cgview_backgroundcolor") ) ;
-    h5->Add ( showrestrictionsites , 0 , wxEXPAND|wxALL , 5 ) ;
-    h5->Add ( showgc , 0 , wxEXPAND|wxALL , 5 ) ;
-    h5->Add ( bgc , 0 , wxEXPAND|wxALL , 5 ) ;
+    h5->Add ( showrestrictionsites , 0 , wxEXPAND , 5 ) ;
+    h5->Add ( showgc , 0 , wxEXPAND , 5 ) ;
+    h5->Add ( bgc , 0 , wxEXPAND , 5 ) ;
 
     
     h2->Add ( new wxButton ( this , wxID_OK , txt("b_ok" ) ) , 0 , wxALL , 5 ) ;

--- a/CGview.cpp
+++ b/CGview.cpp
@@ -111,7 +111,7 @@ void CGdialog::OnRunCGviewer ( wxCommandEvent &event )
 
 void CGdialog::OnChooseJar ( wxCommandEvent &event )
 	{
-    wxFileDialog d ( this , txt("t_cgview_choose_jar") , cgviewapp->GetLabel() , _T("") , _T("cgview.jar|cgview.jar") , wxOPEN ) ;
+    wxFileDialog d ( this , txt("t_cgview_choose_jar") , cgviewapp->GetLabel() , _T("") , _T("cgview.jar|cgview.jar") , wxFD_OPEN ) ;
     if ( wxID_OK != d.ShowModal() ) return ;
     cgviewapp->SetLabel ( d.GetPath() ) ;
 	}

--- a/ChildBase.cpp
+++ b/ChildBase.cpp
@@ -223,7 +223,7 @@ void ChildBase::OnExport (wxCommandEvent& event)
 
 	 wxString wildcard = getExportFilters () ;
     wxString lastdir = myapp()->frame->LS->getOption ( _T("LAST_IMPORT_DIR") , _T("C:") ) ;
-    wxFileDialog d ( this , txt("export_file") , lastdir , _T("") , wildcard , wxSAVE|wxOVERWRITE_PROMPT ) ;
+    wxFileDialog d ( this , txt("export_file") , lastdir , _T("") , wildcard , wxFD_SAVE|wxFD_OVERWRITE_PROMPT ) ;
     d.SetFilterIndex ( myapp()->frame->LS->getOption ( _T("LAST_EXPORT_FILTER") , 0 ) ) ;
     int x = d.ShowModal() ;
     if ( x != wxID_OK ) return ;

--- a/CloningAssistant.cpp
+++ b/CloningAssistant.cpp
@@ -206,8 +206,8 @@ void TCloningAssistantPanel::Refresh (bool eraseBackground , const wxRect* rect 
 void TCloningAssistantPanel::OnEvent(wxMouseEvent& event)
 	{
 	if ( timer.move_back ) return ;
-	wxPaintEvent ev ;
-	OnPaint ( ev ) ;	
+	Refresh();
+	Update();
     wxPoint pt(event.GetPosition());
 	
 	TDDR *over = NULL ;
@@ -509,7 +509,7 @@ void TDDR::draw ( wxDC &dc , wxPoint off )
 
 void TDDR::resizeForText ( wxDC &dc )
 	{
-	long w , h ;
+	wxCoord w , h ;
 	dc.GetTextExtent ( title , &w , &h ) ;
 	r.SetWidth ( w + 4 ) ;
 	r.SetHeight ( h + 4 ) ;

--- a/ExternalBLAST.cpp
+++ b/ExternalBLAST.cpp
@@ -180,7 +180,7 @@ void EIpanel::process_blast()
     blast_res.Empty() ;
     wxString seq = t1->GetValue() ;
     blast_thread = new blastThread ( this , seq ) ;
-    if ( !blast_thread || wxTHREAD_NO_ERROR != blast_thread->Create() )
+    if ( !blast_thread || wxTHREAD_NO_ERROR != blast_thread->CreateThread() )
     {
 	blast_thread = NULL ;
 	return ;

--- a/ExternalBLAST.cpp
+++ b/ExternalBLAST.cpp
@@ -39,8 +39,8 @@ void EIpanel::init_blast()
     st_msg = new wxStaticText ( up , -1 , _T("") ) ;
 
     v1->Add ( h0 , 0 , wxEXPAND , 0 ) ;
-//    v1->Add ( h1 , 0 , wxEXPAND|wxTOP|wxBOTTOM , 3 ) ;
-    v1->Add ( st_msg , 0 , wxEXPAND|wxTOP|wxBOTTOM , 3 ) ;
+//    v1->Add ( h1 , 0 , wxEXPAND , 3 ) ;
+    v1->Add ( st_msg , 0 , wxEXPAND , 3 ) ;
     up->SetSizer ( v1 ) ;
 
     c1->SetSelection ( 0 ) ;

--- a/ExternalInterface.cpp
+++ b/ExternalInterface.cpp
@@ -89,7 +89,7 @@ void ExternalInterface::initme ()
        myapp()->frame->setDummyToolbar ( this ) ;
        myapp()->frame->addDefaultTools ( toolbar ) ;
        toolbar->Realize() ;
-       v0->Add ( toolbar , 0 , wxEXPAND|wxBOTTOM , 2 ) ;
+       v0->Add ( toolbar , 0 , wxEXPAND , 2 ) ;
        }
     v0->Add ( nb , 1 , wxEXPAND , 5 ) ;
     SetSizer ( v0 ) ;

--- a/ExternalNCBI.cpp
+++ b/ExternalNCBI.cpp
@@ -60,8 +60,8 @@ void EIpanel::init_ncbi()
     st_msg = new wxStaticText ( up , -1 , _T("") ) ;
     
     v1->Add ( h0 , 0 , wxEXPAND , 0 ) ;
-    v1->Add ( h1 , 0 , wxEXPAND|wxTOP|wxBOTTOM , 3 ) ;
-    v1->Add ( st_msg , 0 , wxEXPAND|wxTOP|wxBOTTOM , 3 ) ;
+    v1->Add ( h1 , 0 , wxEXPAND , 3 ) ;
+    v1->Add ( st_msg , 0 , wxEXPAND , 3 ) ;
     up->SetSizer ( v1 ) ;
     v1->Fit ( up ) ;
     v1->Show ( h1 , false ) ; // Hide PubMed specifics

--- a/FindSequenceDialog.cpp
+++ b/FindSequenceDialog.cpp
@@ -59,45 +59,45 @@ FindSequenceDialog::FindSequenceDialog ( wxWindow *parent, const wxString& title
                               wxDefaultPosition , wxDefaultSize , wxTE_READONLY|wxSTATIC_BORDER ) ;
     status->SetBackgroundColour ( GetBackgroundColour() ) ;
     find_button = new wxButton ( this , SH_SEARCH , txt("b_find") ) ;
-    h0->Add ( find_button , 1 , wxALL|wxEXPAND , 2 ) ;
-    h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxALL|wxEXPAND , 2 ) ;
-    h0->Add ( new wxButton ( this , SH_CANCEL , txt("b_cancel") ) , 1 , wxALL|wxEXPAND , 2 ) ;
+    h0->Add ( find_button , 1 , wxEXPAND , 2 ) ;
+    h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxEXPAND , 2 ) ;
+    h0->Add ( new wxButton ( this , SH_CANCEL , txt("b_cancel") ) , 1 , wxEXPAND , 2 ) ;
     // Highlight stuff
     highlight_display = new wxStaticText ( this , -1 , _T("      ") ) ;
     do_highlight = new wxButton ( this , FD_ADD_HIGHLIGHTS , txt("b_find_highlight") ) ;
-    h1->Add ( do_highlight , 0 , wxALL|wxEXPAND , 2 ) ;
-    h1->Add ( highlight_display , 0 , wxLEFT|wxEXPAND , 5 ) ;
-    h1->Add ( new wxButton ( this , FD_SET_HIGHLIGHT_COLOR , txt("b_find_highlight_color") ) , 0 , wxALL|wxEXPAND , 2 ) ;
-    h1->Add ( new wxButton ( this , FD_RESET_HIGHLIGHTS , txt("b_find_remove_highlights") ) , 0 , wxALL|wxEXPAND , 2 ) ;
+    h1->Add ( do_highlight , 0 , wxEXPAND , 2 ) ;
+    h1->Add ( highlight_display , 0 , wxEXPAND , 5 ) ;
+    h1->Add ( new wxButton ( this , FD_SET_HIGHLIGHT_COLOR , txt("b_find_highlight_color") ) , 0 , wxEXPAND , 2 ) ;
+    h1->Add ( new wxButton ( this , FD_RESET_HIGHLIGHTS , txt("b_find_remove_highlights") ) , 0 , wxEXPAND , 2 ) ;
     highlight_display->SetBackgroundColour ( highlight ) ;
     // Options
     cb_sequence = cb_items = cb_enzymes = cb_translation = NULL ;
     cb_sequence = new wxCheckBox ( this , SH_CB_SEQUENCE , txt("t_sh_cb_sequence") ) ;
-    h2->Add ( cb_sequence , 0 , wxALL|wxEXPAND , 2 ) ;
+    h2->Add ( cb_sequence , 0 , wxEXPAND , 2 ) ;
     cb_sequence->SetValue ( true ) ;
     if ( c->def != _T("ABIviewer") )
     {
         cb_items = new wxCheckBox ( this , SH_CB_ITEMS , txt("t_sh_cb_items") ) ;
-        h2->Add ( cb_items , 0 , wxALL|wxEXPAND , 2 ) ;
+        h2->Add ( cb_items , 0 , wxEXPAND , 2 ) ;
         cb_items->SetValue ( true ) ;
     }
     if ( c->def == _T("dna") || c->def == _T("PrimerDesign") )
     {
         cb_enzymes = new wxCheckBox ( this , SH_CB_ENZYMES , txt("t_sh_cb_enzymes") ) ;
         cb_translation = new wxCheckBox ( this , SH_CB_TRANSLATION , txt("t_sh_cb_translation") ) ;
-        h2->Add ( cb_enzymes , 0 , wxALL|wxEXPAND , 2 ) ;
-        h2->Add ( cb_translation , 0 , wxALL|wxEXPAND , 2 ) ;
+        h2->Add ( cb_enzymes , 0 , wxEXPAND , 2 ) ;
+        h2->Add ( cb_translation , 0 , wxEXPAND , 2 ) ;
         cb_enzymes->SetValue ( true ) ;
         cb_translation->SetValue ( true ) ;
     }
 
     lb = new wxListBox ( this , SH_LB ) ;
-    v0->Add ( t , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( h0 , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( h1 , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( h2 , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( status , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( lb , 1 , wxALL|wxEXPAND , 2 ) ;
+    v0->Add ( t , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( h0 , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( h1 , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( h2 , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( status , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( lb , 1 , wxEXPAND , 2 ) ;
     do_highlight->Disable() ;
     find_button->SetDefault () ;
     t->SetFocus () ;

--- a/ManageDatabase.cpp
+++ b/ManageDatabase.cpp
@@ -634,7 +634,7 @@ void TManageDatabaseDialog::pdOnDBchange ( wxCommandEvent &ev )
 void TManageDatabaseDialog::pdOnNew ( wxCommandEvent &ev )
     {
     wxString wildcard = _T("GENtle database (*.db)|*.db") ;
-    wxFileDialog d ( this , txt("t_add_new_db") , _T("") , _T("") , wildcard , wxSAVE|wxOVERWRITE_PROMPT ) ;
+    wxFileDialog d ( this , txt("t_add_new_db") , _T("") , _T("") , wildcard , wxFD_SAVE|wxFD_OVERWRITE_PROMPT ) ;
     int x = d.ShowModal() ;
     if ( x != wxID_OK ) return ;
 
@@ -655,7 +655,7 @@ void TManageDatabaseDialog::pdOnNew ( wxCommandEvent &ev )
 void TManageDatabaseDialog::pdOnAdd ( wxCommandEvent &ev )
     {
     wxString wildcard = _T("GENtle database (*.db)|*.db") ;
-    wxFileDialog d ( this , txt("t_choose_db") , _T("") , _T("") , wildcard , wxOPEN ) ;
+    wxFileDialog d ( this , txt("t_choose_db") , _T("") , _T("") , wildcard , wxFD_OPEN ) ;
     int x = d.ShowModal() ;
     if ( x != wxID_OK ) return ;
     
@@ -965,7 +965,7 @@ bool TManageDatabaseDialog::do_load_DNA ( wxString name , wxString db )
         TVectorItem i ;
         i.name = sr[a][sr["di_name"]] ;
         i.desc = sr[a][sr["di_description"]] ;
-        i.setType ( sr[a][sr["di_type"]].GetChar(0) ) ;
+        i.setType ( (char)sr[a][sr["di_type"]].GetChar(0) ) ;
         i.from = atoi ( sr[a][sr["di_from"]].mb_str() ) ;
         i.to = atoi ( sr[a][sr["di_to"]].mb_str() ) ;
         i.setDirection ( atoi ( sr[a][sr["di_direction"]].mb_str() ) ) ;

--- a/ManageDatabase.cpp
+++ b/ManageDatabase.cpp
@@ -159,10 +159,10 @@ void TManageDatabaseDialog::initCopynMove ()
     pm_left->SetImageList ( il , wxIMAGE_LIST_SMALL ) ;
     pm_right->SetImageList ( il , wxIMAGE_LIST_SMALL ) ;
     
-	h1->Add (  new wxStaticText ( p , -1 , txt("t_filter") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h1->Add ( filter_txt , 1 , wxEXPAND|wxALL , 2 ) ;
+	h1->Add (  new wxStaticText ( p , -1 , txt("t_filter") ) , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( filter_txt , 1 , wxEXPAND , 2 ) ;
 
-	h2->Add ( f_twopanes , 0 , wxEXPAND|wxALL , 2 ) ;
+	h2->Add ( f_twopanes , 0 , wxEXPAND , 2 ) ;
 
     if ( !isProject )
        {
@@ -174,25 +174,25 @@ void TManageDatabaseDialog::initCopynMove ()
        f_seq = new wxCheckBox ( p , MD_PM_FILTER_SEQ , txt("sequences") ) ;
        f_desc->SetValue ( 1 ) ;
 
-	   h2->Add ( new wxStaticText ( p , -1 , _T("") ) , 1 , wxEXPAND|wxALL , 2 ) ; // Dummy to shove the rest to the right
-	   h2->Add ( f_dna , 0 , wxEXPAND|wxALL , 2 ) ;
-	   h2->Add ( f_prot , 0 , wxEXPAND|wxALL , 2 ) ;
-	   h2->Add ( f_primer , 0 , wxEXPAND|wxALL , 2 ) ;
-	   h2->Add ( f_align , 0 , wxEXPAND|wxALL , 2 ) ;
-	   h2->Add ( f_desc , 0 , wxEXPAND|wxALL , 2 ) ;
-	   h2->Add ( f_seq , 0 , wxEXPAND|wxALL , 2 ) ;
+	   h2->Add ( new wxStaticText ( p , -1 , _T("") ) , 1 , wxEXPAND , 2 ) ; // Dummy to shove the rest to the right
+	   h2->Add ( f_dna , 0 , wxEXPAND , 2 ) ;
+	   h2->Add ( f_prot , 0 , wxEXPAND , 2 ) ;
+	   h2->Add ( f_primer , 0 , wxEXPAND , 2 ) ;
+	   h2->Add ( f_align , 0 , wxEXPAND , 2 ) ;
+	   h2->Add ( f_desc , 0 , wxEXPAND , 2 ) ;
+	   h2->Add ( f_seq , 0 , wxEXPAND , 2 ) ;
 	   }
 
-	v1->Add ( pm_dd_l , 0 , wxEXPAND|wxALL , 2 ) ;
-	v1->Add ( pm_left , 1 , wxEXPAND|wxALL , 2 ) ;
-	v2->Add ( pm_dd_r , 0 , wxEXPAND|wxALL , 2 ) ;
-	v2->Add ( pm_right , 1 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( v1 , 1 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( v2 , 1 , wxEXPAND|wxALL , 2 ) ;
+	v1->Add ( pm_dd_l , 0 , wxEXPAND , 2 ) ;
+	v1->Add ( pm_left , 1 , wxEXPAND , 2 ) ;
+	v2->Add ( pm_dd_r , 0 , wxEXPAND , 2 ) ;
+	v2->Add ( pm_right , 1 , wxEXPAND , 2 ) ;
+	h3->Add ( v1 , 1 , wxEXPAND , 2 ) ;
+	h3->Add ( v2 , 1 , wxEXPAND , 2 ) ;
 
-	v0->Add ( h1 , 0 , wxEXPAND|wxALL , 2 ) ;
-	v0->Add ( h2 , 0 , wxEXPAND|wxALL , 2 ) ;
-	v0->Add ( h3 , 1 , wxEXPAND|wxALL , 2 ) ;
+	v0->Add ( h1 , 0 , wxEXPAND , 2 ) ;
+	v0->Add ( h2 , 0 , wxEXPAND , 2 ) ;
+	v0->Add ( h3 , 1 , wxEXPAND , 2 ) ;
 
     if ( !doSave )
         {
@@ -211,10 +211,10 @@ void TManageDatabaseDialog::initCopynMove ()
 		sb->SetDefault () ;
 		pm_name->SetSelection ( -1 , -1 ) ;
 		pm_name->SetFocus() ;
-		h4->Add ( pm_dd_save , 0 , wxEXPAND|wxALL , 2 ) ;
-		h4->Add ( pm_name , 1 , wxEXPAND|wxALL , 2 ) ;
-		h4->Add ( sb , 0 , wxEXPAND|wxALL , 2 ) ;
-		v0->Add ( h4 , 0 , wxEXPAND|wxALL , 2 ) ;
+		h4->Add ( pm_dd_save , 0 , wxEXPAND , 2 ) ;
+		h4->Add ( pm_name , 1 , wxEXPAND , 2 ) ;
+		h4->Add ( sb , 0 , wxEXPAND , 2 ) ;
+		v0->Add ( h4 , 0 , wxEXPAND , 2 ) ;
 		}
 	
 	p->SetSizer ( v0 ) ;
@@ -570,7 +570,7 @@ void TManageDatabaseDialog::initDatabases ()
     v1->Add ( pd_db_name , 0 , wxEXPAND , 5 ) ;
     v1->Add ( pd_db_file , 0 , wxEXPAND , 5 ) ;
     v1->Add ( new wxStaticText ( p , -1 , _T("") ) , 0 , wxEXPAND , 5 ) ;
-    v1->Add ( g1 , 1 , wxEXPAND | wxALL , 5 ) ;
+    v1->Add ( g1 , 1 , wxEXPAND , 5 ) ;
     
     pd_db = new wxListBox ( p , MD_PD_DBLIST ) ;
     h1->Add ( pd_db , 1 , wxEXPAND , 5 ) ;

--- a/MiscDialogs.cpp
+++ b/MiscDialogs.cpp
@@ -70,11 +70,11 @@ TGraphDialog::TGraphDialog ( wxWindow *_parent , const wxString& title )
 	add_nb_graph () ;
 	add_nb_data () ;
 	add_nb_scales () ;
-	
+
 	h_buttons->Add ( new wxButton ( this , TGD_OK , txt("b_ok") ) , 1 , 0 ) ;
 	h_buttons->Add ( new wxStaticText ( this , -1 , _T(" ") ) , 1 , wxEXPAND ) ;
 	h_buttons->Add ( new wxButton ( this , wxID_CANCEL , txt("b_cancel") ) , 1 , 0 ) ;
-	
+
 	v0->Add ( nb , 1 , wxEXPAND , 0 ) ;
 	v0->Add ( h_buttons , 0 , wxALL|wxALIGN_CENTER_HORIZONTAL , 5 ) ;
 	
@@ -138,8 +138,8 @@ void TGraphDialog::add_nb_data ()
 	wxBoxSizer *h3 = new wxBoxSizer ( wxHORIZONTAL ) ;
 	
 	data_name = new wxTextCtrl ( nb_data , -1 ) ;
-	h1->Add ( new wxStaticText ( nb_data , -1 , txt("name") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h1->Add ( data_name , 1 , wxEXPAND|wxALL , 2 ) ;
+	h1->Add ( new wxStaticText ( nb_data , -1 , txt("name") ) , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( data_name , 1 , wxEXPAND , 2 ) ;
 	
 	ch_data_scalex = new wxChoice ( nb_data , -1 ) ;
 	ch_data_scaley = new wxChoice ( nb_data , -1 ) ;
@@ -148,28 +148,28 @@ void TGraphDialog::add_nb_data ()
 		ch_data_scalex->Append ( parent->gd->scales[a]->name ) ;
 		ch_data_scaley->Append ( parent->gd->scales[a]->name ) ;
 		}
-	h2->Add ( new wxStaticText ( nb_data , -1 , _T("Scale X") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( ch_data_scalex , 1 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( new wxStaticText ( nb_data , -1 , _T("Scale Y") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( ch_data_scaley , 1 , wxEXPAND|wxALL , 2 ) ;
+	h2->Add ( new wxStaticText ( nb_data , -1 , _T("Scale X") ) , 0 , wxEXPAND , 2 ) ;
+	h2->Add ( ch_data_scalex , 1 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxStaticText ( nb_data , -1 , _T("Scale Y") ) , 0 , wxEXPAND , 2 ) ;
+	h2->Add ( ch_data_scaley , 1 , wxEXPAND , 2 ) ;
 	
 	data_color = new wxTextCtrl ( nb_data , -1 , _T("  ") ) ;
 	ch_data_pointstyle = new wxChoice ( nb_data , -1 ) ;
 	ch_data_pointstyle->Append ( _T("none") ) ;
 	for ( a = 0 ; a < parent->gd->styles.GetCount() ; a++ )
 		ch_data_pointstyle->Append ( parent->gd->styles[a] ) ;
-	h3->Add ( new wxStaticText ( nb_data , -1 , _T("Point style") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( ch_data_pointstyle , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( new wxButton ( nb_data , TGD_BT_DATA , txt("color") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( data_color , 0 , wxEXPAND|wxALL , 2 ) ;
-	
-	v0->Add ( h1 , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h2 , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h3 , 0 , wxEXPAND|wxALL , 5 ) ;	
-		
-	h0->Add ( lb_data , 0 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( v0 , 0 , wxEXPAND|wxALL , 5 ) ;
-	
+	h3->Add ( new wxStaticText ( nb_data , -1 , _T("Point style") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( ch_data_pointstyle , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( new wxButton ( nb_data , TGD_BT_DATA , txt("color") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( data_color , 0 , wxEXPAND , 2 ) ;
+
+	v0->Add ( h1 , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h2 , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h3 , 0 , wxEXPAND , 5 ) ;
+
+	h0->Add ( lb_data , 0 , wxEXPAND , 5 ) ;
+	h0->Add ( v0 , 0 , wxEXPAND , 5 ) ;
+
 	nb_data->SetSizer ( h0 ) ;
 	h0->Fit ( nb_data ) ;
 
@@ -204,34 +204,34 @@ void TGraphDialog::add_nb_scales ()
 	wxBoxSizer *h3 = new wxBoxSizer ( wxHORIZONTAL ) ;
 
 	scales_name = new wxTextCtrl ( nb_scales , -1 ) ;
-	h1->Add ( new wxStaticText ( nb_scales , -1 , txt("name") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h1->Add ( scales_name , 1 , wxEXPAND|wxALL , 2 ) ;
+	h1->Add ( new wxStaticText ( nb_scales , -1 , txt("name") ) , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( scales_name , 1 , wxEXPAND , 2 ) ;
 
 	scales_min = new wxTextCtrl ( nb_scales , -1 ) ;
 	scales_max = new wxTextCtrl ( nb_scales , -1 ) ;
-	h2->Add ( new wxStaticText ( nb_scales , -1 , _T("Min") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( scales_min , 1 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( new wxStaticText ( nb_scales , -1 , _T("Max") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( scales_max , 1 , wxEXPAND|wxALL , 2 ) ;
+	h2->Add ( new wxStaticText ( nb_scales , -1 , _T("Min") ) , 0 , wxEXPAND , 2 ) ;
+	h2->Add ( scales_min , 1 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxStaticText ( nb_scales , -1 , _T("Max") ) , 0 , wxEXPAND , 2 ) ;
+	h2->Add ( scales_max , 1 , wxEXPAND , 2 ) ;
 
 	scales_color = new wxTextCtrl ( nb_scales , -1 , _T("  ") ) ;
 	scales_unit = new wxTextCtrl ( nb_scales , -1 ) ;
 	ch_scales_type = new wxChoice ( nb_scales , -1 ) ;
 	for ( a = 0 ; a < parent->gd->scaleTypes.GetCount() ; a++ )
 		ch_scales_type->Append ( parent->gd->scaleTypes[a] ) ;
-	h3->Add ( new wxStaticText ( nb_scales , -1 , _T("Unit") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( scales_unit , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( new wxStaticText ( nb_scales , -1 , _T("Type") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( ch_scales_type , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( new wxButton ( nb_scales , TGD_BT_SCALES , txt("color") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	h3->Add ( scales_color , 0 , wxEXPAND|wxALL , 2 ) ;
+	h3->Add ( new wxStaticText ( nb_scales , -1 , _T("Unit") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( scales_unit , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( new wxStaticText ( nb_scales , -1 , _T("Type") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( ch_scales_type , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( new wxButton ( nb_scales , TGD_BT_SCALES , txt("color") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( scales_color , 0 , wxEXPAND , 2 ) ;
 
-	v0->Add ( h1 , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h2 , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h3 , 0 , wxEXPAND|wxALL , 5 ) ;
+	v0->Add ( h1 , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h2 , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h3 , 0 , wxEXPAND , 5 ) ;
 	
-	h0->Add ( lb_scales , 0 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( v0 , 0 , wxEXPAND|wxALL , 5 ) ;
+	h0->Add ( lb_scales , 0 , wxEXPAND , 5 ) ;
+	h0->Add ( v0 , 0 , wxEXPAND , 5 ) ;
 	
 	nb_scales->SetSizer ( h0 ) ;
 	h0->Fit ( nb_scales ) ;
@@ -374,8 +374,8 @@ TSpeakDialog::TSpeakDialog(wxWindow *parent, const wxString& title , wxString _s
 	wxButton *b1 = new wxButton ( this , SPEAK_PLAY , txt("b_speak_play") ) ;
 	wxButton *b2 = new wxButton ( this , SPEAK_STOP , txt("b_speak_stop") ) ;
 	
-	h0->Add ( b1 , 1 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( b2 , 1 , wxEXPAND|wxALL , 5 ) ;
+	h0->Add ( b1 , 1 , wxEXPAND , 5 ) ;
+	h0->Add ( b2 , 1 , wxEXPAND , 5 ) ;
 	
 	doPause = new wxCheckBox ( this , -1 , txt("t_speak_do_pause") ) ;
 	pause = new wxSpinCtrl ( this , -1 ) ;
@@ -383,16 +383,16 @@ TSpeakDialog::TSpeakDialog(wxWindow *parent, const wxString& title , wxString _s
 	pause->SetRange ( 1 , 10 ) ;
 	pause->SetValue ( _T("3") ) ;
 
-	h1->Add ( doPause , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1->Add ( pause , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1->Add ( new wxStaticText ( this , -1 , txt("t_speak_pause") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	
-	v0->Add ( seq , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h1 , 0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h0 , 0 , wxEXPAND|wxALL , 5 ) ;
+	h1->Add ( doPause , 0 , wxEXPAND , 5 ) ;
+	h1->Add ( pause , 0 , wxEXPAND , 5 ) ;
+	h1->Add ( new wxStaticText ( this , -1 , txt("t_speak_pause") ) , 0 , wxEXPAND , 5 ) ;
 
-	
-	
+	v0->Add ( seq , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h1 , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
+
+
+
 	SetSizer ( v0 ) ;
 	v0->Fit ( this ) ;
 	
@@ -556,7 +556,7 @@ TSequencingPrimerDialog::TSequencingPrimerDialog (wxWindow *parent, const wxStri
     c_db = new wxChoice ( this , SPD_DB ) ;
     h1->Add ( new wxStaticText ( this , -1 , txt("t_use_this_database") ) , 0 , wxEXPAND ) ;
     h1->Add ( c_db , 0 , wxEXPAND ) ;
-    
+
     myapp()->frame->LS->getDatabaseList ( db_names , db_files ) ;
     for ( int a = 0 ; a < db_names.GetCount() ; a++ )
 	    c_db->Append ( db_names[a] ) ;
@@ -581,15 +581,15 @@ TSequencingPrimerDialog::TSequencingPrimerDialog (wxWindow *parent, const wxStri
     cb_35->SetValue ( TRUE ) ;
     cb_53->SetValue ( TRUE ) ;
     
-    h3->Add ( new wxButton ( this , wxID_OK , txt("b_ok") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-    h3->Add ( new wxButton ( this , wxID_CANCEL , txt("b_cancel") ) , 0 , wxEXPAND|wxALL , 5 ) ;
+    h3->Add ( new wxButton ( this , wxID_OK , txt("b_ok") ) , 0 , wxEXPAND , 5 ) ;
+    h3->Add ( new wxButton ( this , wxID_CANCEL , txt("b_cancel") ) , 0 , wxEXPAND , 5 ) ;
     
     v0->Add ( h0 , 0 , wxALL , 5 ) ;
-    v0->Add ( h1 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( h1a , 0 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( h2a , 0 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( h2 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( h3 , 0 , wxEXPAND|wxALL|wxALIGN_CENTER_VERTICAL , 5 ) ;
+    v0->Add ( h1 , 0 , wxEXPAND , 5 ) ;
+    v0->Add ( h1a , 0 , wxEXPAND , 5 ) ;
+    v0->Add ( h2a , 0 , wxEXPAND , 5 ) ;
+    v0->Add ( h2 , 0 , wxEXPAND , 5 ) ;
+    v0->Add ( h3 , 0 , wxEXPAND , 5 ) ;
     
     SetSizer ( v0 ) ;
     v0->Fit ( this ) ;    
@@ -838,17 +838,17 @@ TMyMultipleChoiceDialog::TMyMultipleChoiceDialog ( wxWindow *parent ,
    if ( options & wxCANCEL )
 		{
 		wxButton *b = new wxButton ( this , wxID_CANCEL , txt("b_cancel") ) ;
-		h0->Add ( b , wxEXPAND|wxALL , 2 ) ;
+		h0->Add ( b , wxEXPAND , 2 ) ;
 		}
-	else h0->Add ( new wxStaticText ( this , -1 , _T("") ) , wxEXPAND|wxALL , 2 ) ;
+	else h0->Add ( new wxStaticText ( this , -1 , _T("") ) , wxEXPAND , 2 ) ;
 
    if ( options & wxOK )
 		{
 		wxButton *b = new wxButton ( this , MCD_OK , txt("b_ok") ) ;
-		h0->Add ( b , wxEXPAND|wxALL , 2 ) ;
+		h0->Add ( b , wxEXPAND , 2 ) ;
 		b->SetDefault() ;
 		}
-	else h0->Add ( new wxStaticText ( this , -1 , _T("") ) , wxEXPAND|wxALL , 2 ) ;
+	else h0->Add ( new wxStaticText ( this , -1 , _T("") ) , wxEXPAND , 2 ) ;
 
 	clb = new wxCheckListBox ( this , 
                                  -1 , 
@@ -858,9 +858,9 @@ TMyMultipleChoiceDialog::TMyMultipleChoiceDialog ( wxWindow *parent ,
                                  choices ) ;
 
    if ( !message.IsEmpty() )
-		v0->Add ( new wxStaticText ( this , -1 , message ) , 0 , wxEXPAND|wxALL , 2 ) ;
-	v0->Add ( clb , 1 , wxEXPAND|wxALL , 2 ) ;
-	v0->Add ( h0 , 0 , wxEXPAND|wxALL , 2 ) ;
+		v0->Add ( new wxStaticText ( this , -1 , message ) , 0 , wxEXPAND , 2 ) ;
+	v0->Add ( clb , 1 , wxEXPAND , 2 ) ;
+	v0->Add ( h0 , 0 , wxEXPAND , 2 ) ;
    
    SetSizer ( v0 ) ;
    v0->Layout () ;

--- a/MyChild.cpp
+++ b/MyChild.cpp
@@ -1141,7 +1141,7 @@ bool MyChild::runRestriction ( wxString s )
 	{
     MyFrame *f = myapp()->frame ; //(MyFrame*) GetParent() ;
     TRestrictionEditor ed ( f , _T("") , wxPoint(-1,-1) , wxSize(600,400) ,
-               wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL);
+               wxDEFAULT_DIALOG_STYLE|wxCENTRE);
     ed.pre = s ;
     ed.cocktail = vec->cocktail ;
     ed.remoteCocktail = &vec->cocktail ;

--- a/MyChild.cpp
+++ b/MyChild.cpp
@@ -506,8 +506,8 @@ void MyChild::initme ()
 
     wxSafeYield() ;
     wxBoxSizer *v0 = new wxBoxSizer ( wxVERTICAL ) ;
-    v0->Add ( toolbar , 0 , wxALL|wxEXPAND , 2 ) ;
-    v0->Add ( sw , 1 , wxALL|wxEXPAND , 2 ) ;
+    v0->Add ( toolbar , 0 , wxEXPAND , 2 ) ;
+    v0->Add ( sw , 1 , wxEXPAND , 2 ) ;
     SetSizer ( v0 ) ;
     v0->Fit ( this ) ;
 	

--- a/MyChild.cpp
+++ b/MyChild.cpp
@@ -397,30 +397,36 @@ void MyChild::initToolbar ()
         myapp()->frame->addTool ( toolBar , SEQ_PRINT ) ;
         myapp()->frame->addCCPFTools ( toolBar , true ) ;
         toolBar->AddTool( MDI_CIRCULAR_LINEAR,
+            wxEmptyString,
             myapp()->frame->bitmaps[7],
             myapp()->frame->bitmaps[8],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_toggle_rc") ) ;
+            wxITEM_CHECK, txt("m_toggle_rc") ) ;
         toolBar->AddTool( MDI_ORFS,
+            wxEmptyString,
             myapp()->frame->bitmaps[9],
             myapp()->frame->bitmaps[9],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_orfs") ) ;
+            wxITEM_CHECK, txt("m_orfs") ) ;
         toolBar->AddTool( MDI_TOGGLE_FEATURES,
+            wxEmptyString,
             myapp()->frame->bitmaps[10],
             myapp()->frame->bitmaps[10],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_display_features") ) ;
+            wxITEM_CHECK, txt("m_display_features") ) ;
         toolBar->AddTool( MDI_TOGGLE_RESTRICTION,
+            wxEmptyString,
             myapp()->frame->bitmaps[11],
             myapp()->frame->bitmaps[11],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_display_restriction") ) ;        
+            wxITEM_CHECK, txt("m_display_restriction") ) ;
         toolBar->AddSeparator() ;
         toolBar->AddTool( MDI_VIEW_MODE,
+            wxEmptyString,
             myapp()->frame->bitmaps[12],
             myapp()->frame->bitmaps[12],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_view_mode") ) ;
+            wxITEM_CHECK, txt("m_view_mode") ) ;
         toolBar->AddTool( MDI_EDIT_MODE,
+            wxEmptyString,
             myapp()->frame->bitmaps[13],
             myapp()->frame->bitmaps[13],
-            TRUE, -1, -1, (wxObject *) NULL, txt("m_edit_mode") ) ;
+            wxITEM_CHECK, txt("m_edit_mode") ) ;
         toolBar->AddSeparator() ;
         toolBar->AddControl ( new wxStaticText ( toolBar , -1 , txt("t_zoom") ) ) ;
 #ifdef __WXMSW__
@@ -1518,14 +1524,14 @@ void MyChild::updateUndoMenu ()
     bool canUndo ;
     if ( lm.IsEmpty() )
         {
-        mi->SetText ( txt("u_no") ) ;
+        mi->SetItemLabel ( txt("u_no") ) ;
         mi->Enable ( false ) ;
 	    canUndo = false ;
         }
     else
         {
         mi->Enable ( true ) ;
-        mi->SetText ( lm ) ;
+        mi->SetItemLabel ( lm ) ;
 	    canUndo = true ;
         }
     allow_undo = canUndo ;

--- a/MyFrame.cpp
+++ b/MyFrame.cpp
@@ -1223,14 +1223,17 @@ void MyFrame::addTool ( wxToolBar* toolBar , int id )
 	
 	if ( id == MDI_TEXT_IMPORT )
 		toolBar->AddTool( MDI_TEXT_IMPORT ,
+						 wxEmptyString,
 						 bitmaps[0],
 						 txt("m_new_sequence") ) ;  
 	else if ( id == MDI_FILE_IMPORT )
 		toolBar->AddTool( MDI_FILE_IMPORT, 
+						 wxEmptyString,
 						 bitmaps[14],
 						 txt("m_importtxt") );
 	else if ( id == MDI_FILE_OPEN )
 		toolBar->AddTool( MDI_FILE_OPEN, 
+						 wxEmptyString,
 						 bitmaps[1],
 						 txt("m_opentxt") );
 	else if ( id == MDI_FILE_SAVE )
@@ -1266,11 +1269,11 @@ void MyFrame::addDefaultTools(wxToolBar* toolBar)
 {
 	if ( mainToolBar && toolBar != mainToolBar ) return ;
  	toolBar->AddSeparator() ;
- 	toolBar->AddTool( MDI_ALIGNMENT, myapp()->frame->bitmaps[17] , txt("m_alignment_text") ) ;
- 	toolBar->AddTool( MDI_IMAGE_VIEWER, myapp()->frame->bitmaps[18] , txt("m_imageviewer_text") ) ;
- 	toolBar->AddTool( MDI_CALCULATOR, myapp()->frame->bitmaps[20] , txt("m_calculator_text") ) ;
- 	toolBar->AddTool( PROGRAM_OPTIONS, myapp()->frame->bitmaps[21] , txt("m_options_text") ) ;
- 	toolBar->AddTool( MDI_EXTERNAL_INTERFACE, myapp()->frame->bitmaps[19] , txt("m_external_text") ) ;
+ 	toolBar->AddTool( MDI_ALIGNMENT, wxEmptyString, myapp()->frame->bitmaps[17] , txt("m_alignment_text") ) ;
+ 	toolBar->AddTool( MDI_IMAGE_VIEWER, wxEmptyString, myapp()->frame->bitmaps[18] , txt("m_imageviewer_text") ) ;
+ 	toolBar->AddTool( MDI_CALCULATOR, wxEmptyString, myapp()->frame->bitmaps[20] , txt("m_calculator_text") ) ;
+ 	toolBar->AddTool( PROGRAM_OPTIONS, wxEmptyString, myapp()->frame->bitmaps[21] , txt("m_options_text") ) ;
+ 	toolBar->AddTool( MDI_EXTERNAL_INTERFACE, wxEmptyString, myapp()->frame->bitmaps[19] , txt("m_external_text") ) ;
 }
 
 /** \brief Adds cut,copy,paste (and find) tools to a given toolbar

--- a/MyFrame.cpp
+++ b/MyFrame.cpp
@@ -727,7 +727,7 @@ void MyFrame::saveImage ( wxBitmap *bmp , wxString name )
     name.Replace ( _T("\\") , _T("_") , TRUE ) ;
 	
     wxString lastdir = LS->getOption ( _T("LAST_IMPORT_DIR") , _T("C:") ) ;
-    wxFileDialog d ( this , txt("t_save_image") , lastdir , name , wildcard , wxSAVE|wxOVERWRITE_PROMPT ) ;
+    wxFileDialog d ( this , txt("t_save_image") , lastdir , name , wildcard , wxFD_SAVE|wxFD_OVERWRITE_PROMPT ) ;
     if ( d.ShowModal() != wxID_OK ) return ;
     wxString filename = d.GetPath() ;
     
@@ -764,7 +764,7 @@ void MyFrame::OnFileImport(wxCommandEvent& event )
 	_T("|") + wcCM5format ;
     wxString lastdir = LS->getOption ( _T("LAST_IMPORT_DIR") , _T("C:") ) ;
     wxFileDialog d ( this , txt("import_file") , lastdir , 
-					_T("") , wildcard , wxOPEN | wxMULTIPLE ) ;
+					_T("") , wildcard , wxFD_OPEN | wxFD_MULTIPLE ) ;
     int x = d.ShowModal() ;
     if ( x != wxID_OK ) return ;
     
@@ -2616,8 +2616,8 @@ void TTestSuite::vectorPressKey ( ChildBase *ac )
     if ( r == 10 ) { ev.m_keyCode = WXK_LEFT ; msg = _T("LEFT") ; }
     if ( r == 11 ) { ev.m_keyCode = WXK_UP ; msg = _T("UP") ; }
     if ( r == 12 ) { ev.m_keyCode = WXK_DOWN ; msg = _T("DOWN") ; }
-    if ( r == 13 ) { ev.m_keyCode = WXK_PRIOR ; msg = _T("PRIOR") ; }
-    if ( r == 14 ) { ev.m_keyCode = WXK_NEXT ; msg = _T("NEXT") ; }
+    if ( r == 13 ) { ev.m_keyCode = WXK_PAGEUP ; msg = _T("PAGEUP") ; }
+    if ( r == 14 ) { ev.m_keyCode = WXK_PAGEDOWN ; msg = _T("PAGEDOWN") ; }
     mylog ( "Testsuite:Key" , wxString::Format ( "%s" , msg.c_str() ) ) ;
     if ( ac->def == _T("PrimerDesign") ) ((TPrimerDesign*)ac)->sc->OnCharHook(ev) ;
     else ac->cSequence->OnCharHook(ev) ;

--- a/PCR_Troubleshoot.cpp
+++ b/PCR_Troubleshoot.cpp
@@ -37,15 +37,15 @@ PCR_troubleshoot_dialog::PCR_troubleshoot_dialog(TPrimerDesign *_parent, const w
 	text = new wxTextCtrl ( this , -1 , _T("") , wxDefaultPosition , wxDefaultSize , wxTE_MULTILINE ) ;
 	text->SetFont ( *MYFONT ( MYFONTSIZE , wxMODERN , wxNORMAL , wxNORMAL ) ) ;
 	
-	h0->Add ( new wxStaticText ( this , -1 , _T("")) , 1 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( new wxButton ( this , POD_OK , txt("b_ok") ) , 1 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( new wxButton ( this , POD_CANCEL , txt("b_cancel") ) , 1 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxEXPAND|wxALL , 5 ) ;
+	h0->Add ( new wxStaticText ( this , -1 , _T("")) , 1 , wxEXPAND , 5 ) ;
+	h0->Add ( new wxButton ( this , POD_OK , txt("b_ok") ) , 1 , wxEXPAND , 5 ) ;
+	h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxEXPAND , 5 ) ;
+	h0->Add ( new wxButton ( this , POD_CANCEL , txt("b_cancel") ) , 1 , wxEXPAND , 5 ) ;
+	h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , wxEXPAND , 5 ) ;
 	
-	v0->Add ( list , 1 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( text , 2 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h0 , 0 , wxEXPAND|wxALL , 5 ) ;
+	v0->Add ( list , 1 , wxEXPAND , 5 ) ;
+	v0->Add ( text , 2 , wxEXPAND , 5 ) ;
+	v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
 	
 	scan () ;
 	for ( int a = 0 ; a < l_title.GetCount() ; a++ )

--- a/PCR_Troubleshoot.cpp
+++ b/PCR_Troubleshoot.cpp
@@ -415,13 +415,13 @@ void PCR_troubleshoot_dialog::scan_Runs ( TPrimer &p , int nr , int length )
 		if ( ( b - a ) / length > 4 )
 			{
 			add_error ( p , nr , msg ,
-			wxString::Format ( txt("t_pcr_ts_warning_runs_text") , (char*)s.Mid(a,length).c_str() ) ) ;
+			wxString::Format ( txt("t_pcr_ts_warning_runs_text") , (const char*)s.Mid(a,length).c_str() ) ) ;
 			a = b - length ;
 			}
 		else if ( ( b - a ) / length  == 4 )
 			{
 			add_warning ( p , nr , msg ,
-			wxString::Format ( txt("t_pcr_ts_warning_runs_text2") , (char*)s.Mid(a,length).c_str() ) ) ;
+			wxString::Format ( txt("t_pcr_ts_warning_runs_text2") , (const char*)s.Mid(a,length).c_str() ) ) ;
 			a = b - length ;
 			}
 		}
@@ -489,7 +489,7 @@ wxString PCR_troubleshoot_dialog::invert ( wxString s )
 	int a ;
 	for ( a = 0 ; a < s.length() ; a++ )
 		{
-		switch ( s.GetChar ( a ) )
+		switch ( (char)s.GetChar ( a ) )
 			{
 			case 'A' : s.SetChar ( a , 'T' ) ; break ;
 			case 'C' : s.SetChar ( a , 'G' ) ; break ;

--- a/PrimerDesign.cpp
+++ b/PrimerDesign.cpp
@@ -485,9 +485,9 @@ void TPrimerDesign::initme ()
 
     GetToolBar()->ToggleTool(MDI_TOGGLE_FEATURES,show_features);
 
-    h0->Add ( lc , 1 , wxEXPAND|wxALL , 2 ) ;
-    h0->Add ( v1 , 0 , wxEXPAND|wxALL , 2 ) ;
-    h0->Add ( stat , 1 , wxEXPAND|wxALL , 2 ) ;
+    h0->Add ( lc , 1 , wxEXPAND , 2 ) ;
+    h0->Add ( v1 , 0 , wxEXPAND , 2 ) ;
+    h0->Add ( stat , 1 , wxEXPAND , 2 ) ;
 
     v0->Add ( toolbar , 0 , wxEXPAND , 2 ) ;
     v0->Add ( h0 , 0 , wxEXPAND , 2 ) ;

--- a/PrimerDesign.cpp
+++ b/PrimerDesign.cpp
@@ -415,21 +415,25 @@ void TPrimerDesign::initme ()
 	myapp()->frame->addTool ( toolBar , SEQ_PRINT ) ;
     if ( !myapp()->frame->mainToolBar ) toolBar->AddSeparator() ;
     toolBar->AddTool( PD_IMPORT, 
+            wxEmptyString ,
             myapp()->frame->bitmaps[14] ,
             txt("b_import_primer") ) ;
     toolBar->AddTool( PD_EXPORT, 
+            wxEmptyString ,
             myapp()->frame->bitmaps[15] ,
             txt("b_export_primer") ) ;
     toolBar->AddSeparator() ;
 	myapp()->frame->addTool ( toolBar , MDI_COPY ) ;
     toolBar->AddTool( MDI_EDIT_MODE,
+        wxEmptyString ,
         myapp()->frame->bitmaps[13] ,
         myapp()->frame->bitmaps[13] ,
-        TRUE, -1, -1, (wxObject *) NULL, txt("m_edit_mode") ) ;
+        wxITEM_CHECK, txt("m_edit_mode") ) ;
     toolBar->AddTool( MDI_TOGGLE_FEATURES,
+        wxEmptyString ,
         myapp()->frame->bitmaps[10] ,
         myapp()->frame->bitmaps[10] ,
-        TRUE, -1, -1, (wxObject *) NULL, txt("m_display_features") ) ;
+        wxITEM_CHECK, txt("m_display_features") ) ;
     toolBar->AddSeparator() ;
     
     spin = new wxSpinCtrl ( toolBar , PCR_SPIN , _T("") , wxDefaultPosition , wxSize ( MYSPINBOXSIZE , -1 ) ) ;

--- a/ProgramOptionsDialog.cpp
+++ b/ProgramOptionsDialog.cpp
@@ -220,8 +220,8 @@ ProgramOptionsDialog::ProgramOptionsDialog(wxWindow *parent, const wxString& tit
 	h0->Add ( CANCEL , 1 , 0 ) ;
 	h0->Add ( new wxStaticText ( this , -1 , _T("") ) , 1 , 0 ) ;
 
-	v0->Add ( nb , 1 , wxALL|wxEXPAND , 5 ) ;
-	v0->Add ( h0 , 0 , wxALL|wxEXPAND , 5 ) ;
+	v0->Add ( nb , 1 , wxEXPAND , 5 ) ;
+	v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
 
 	SetSizer ( v0 ) ;
 	v0->Fit ( this ) ;
@@ -266,12 +266,12 @@ void ProgramOptionsDialog::initGlobalSettings ()
     proxyPort = new wxTextCtrl ( globalSettingsPanel , -1 , myapp()->frame->proxy.AfterLast(':') ) ;
 
 	// ORF length
-    wxBoxSizer *orf_sizer = new wxBoxSizer ( wxHORIZONTAL ) ;	
+    wxBoxSizer *orf_sizer = new wxBoxSizer ( wxHORIZONTAL ) ;
     orfLength = new wxTextCtrl ( globalSettingsPanel , -1 , wxString::Format ( _T("%d") , myapp()->frame->orfLength ) ) ;
-    orf_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , _T("ORF length") ) , 0 , wxEXPAND|wxALL , 3 ) ;
-    orf_sizer->Add ( orfLength , 1 , wxEXPAND|wxALL , 3 ) ;
+    orf_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , _T("ORF length") ) , 0 , wxEXPAND , 3 ) ;
+    orf_sizer->Add ( orfLength , 1 , wxEXPAND , 3 ) ;
 
-    
+
     // Display options
     enhancedDisplay = new wxCheckBox ( globalSettingsPanel , -1 , 
                         txt("t_enhanced_display") ) ; 
@@ -359,44 +359,44 @@ void ProgramOptionsDialog::initGlobalSettings ()
     else nonstandard_translation_table->SetSelection ( 0 ) ;
 
     wxBoxSizer *proxy_sizer = new wxBoxSizer ( wxHORIZONTAL ) ;
-    proxy_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_proxy_name") ) , 0 , wxEXPAND|wxALL , 3 ) ;
-    proxy_sizer->Add ( proxyName , 1 , wxEXPAND|wxALL , 3 ) ;
-    proxy_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_proxy_port") ) , 0 , wxEXPAND|wxALL , 3 ) ;
-    proxy_sizer->Add ( proxyPort , 0 , wxEXPAND|wxALL , 3 ) ;
+    proxy_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_proxy_name") ) , 0 , wxEXPAND , 3 ) ;
+    proxy_sizer->Add ( proxyName , 1 , wxEXPAND , 3 ) ;
+    proxy_sizer->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_proxy_port") ) , 0 , wxEXPAND , 3 ) ;
+    proxy_sizer->Add ( proxyPort , 0 , wxEXPAND , 3 ) ;
 
     wxBoxSizer *v = new wxBoxSizer ( wxHORIZONTAL ) ;
     wxBoxSizer *h = new wxBoxSizer ( wxHORIZONTAL ) ;
-    h->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_language") ) , 0 , wxEXPAND|wxALL , 3 ) ;
-    h->Add ( language , 0 , wxEXPAND|wxALL , 3 ) ;
+    h->Add ( new wxStaticText ( globalSettingsPanel , -1 , txt("t_language") ) , 0 , wxEXPAND , 3 ) ;
+    h->Add ( language , 0 , wxEXPAND , 3 ) ;
 
-    v->Add ( general_options , 0 , wxEXPAND|wxALL , 3 ) ;
-    v->Add ( display_options , 0 , wxEXPAND|wxALL , 3 ) ;
-	
-    general_options->Add ( h , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( loadLastProject , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( useMetafile , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( checkUpdate , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( useInternalHelp , 0 , wxEXPAND|wxALL , 3 ) ;
-	general_options->Add ( useOnlineHelp , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( doRegisterStuff , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( new wxStaticText ( globalSettingsPanel , -1 , _T("") ) , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( use_nonstandard_translation_table , 0 , wxEXPAND|wxALL , 3 ) ; 
-    general_options->Add ( nonstandard_translation_table , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( proxy_sizer , 0 , wxEXPAND|wxALL , 3 ) ;
-    general_options->Add ( orf_sizer , 0 , wxEXPAND|wxALL , 3 ) ;
-    
-    display_options->Add ( enhancedDisplay , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( vectorTitle , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( vectorLength , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showSplashScreen , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showEnzymePos , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showTips , 0 , wxEXPAND|wxALL , 3 ) ;
-	display_options->Add ( useTwoToolbars , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showToolTips , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showLowercaseDNA , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( editFeatureMode , 0 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( showStopCodon , 1 , wxEXPAND|wxALL , 3 ) ;
-    display_options->Add ( b_aacol, 0 , wxEXPAND|wxALL , 3 ) ;
+    v->Add ( general_options , 0 , wxEXPAND , 3 ) ;
+    v->Add ( display_options , 0 , wxEXPAND , 3 ) ;
+
+    general_options->Add ( h , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( loadLastProject , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( useMetafile , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( checkUpdate , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( useInternalHelp , 0 , wxEXPAND , 3 ) ;
+	general_options->Add ( useOnlineHelp , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( doRegisterStuff , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( new wxStaticText ( globalSettingsPanel , -1 , _T("") ) , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( use_nonstandard_translation_table , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( nonstandard_translation_table , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( proxy_sizer , 0 , wxEXPAND , 3 ) ;
+    general_options->Add ( orf_sizer , 0 , wxEXPAND , 3 ) ;
+
+    display_options->Add ( enhancedDisplay , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( vectorTitle , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( vectorLength , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showSplashScreen , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showEnzymePos , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showTips , 0 , wxEXPAND , 3 ) ;
+	display_options->Add ( useTwoToolbars , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showToolTips , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showLowercaseDNA , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( editFeatureMode , 0 , wxEXPAND , 3 ) ;
+    display_options->Add ( showStopCodon , 1 , wxEXPAND , 3 ) ;
+    display_options->Add ( b_aacol, 0 , wxEXPAND , 3 ) ;
 
 	 globalSettingsPanel->SetSizer ( v ) ;
 	 v->Fit ( globalSettingsPanel ) ;

--- a/SequenceCanvas.cpp
+++ b/SequenceCanvas.cpp
@@ -394,13 +394,13 @@ void SequenceCanvas::editSpecialKeyPressed ( int k , TVector *v , wxString *the_
       {
       mark ( id , the_sequence->length() , the_sequence->length() , 2 ) ;
       }   	
-    else if ( k == WXK_PRIOR )
+    else if ( k == WXK_PAGEUP )
       {
       from -= page ;
       if ( from < 1 ) from = 1 ;
       mark ( id , from , from , 2 ) ;
       }
-    else if ( k == WXK_NEXT )
+    else if ( k == WXK_PAGEDOWN )
       {
       from += page ;
       if ( from > the_sequence->length() ) from = the_sequence->length() ;

--- a/SequenceTypeAAstructure.cpp
+++ b/SequenceTypeAAstructure.cpp
@@ -400,7 +400,7 @@ void SeqAAstructure::draw_amino_acid ( wxDC &dc , char as , int x , int y , int 
 	dc.SetPen ( *pen_C ) ;
 	for ( a = 0 ; a < atom_pos.size() ; a++ )
 		{
-		switch ( atom_type.GetChar ( a ) )
+		switch ( (char)atom_type.GetChar ( a ) )
 			{
 			case 'C' : if ( can->isPrinting() ) dc.SetPen ( *pen_C ) ; dc.SetBrush ( *brush_C ) ; break ;
 			case 'S' : if ( can->isPrinting() ) dc.SetPen ( *pen_S ) ; dc.SetBrush ( *brush_S ) ; break ;

--- a/SequenceTypePlot.cpp
+++ b/SequenceTypePlot.cpp
@@ -538,7 +538,7 @@ void SeqPlot::useNcoils ()
 		mylog ( "SeqPlot::useNcoils" , wxString::Format ( _T("BEGIN ncoils_function (%d): ") , b ) + s ) ;
 		x = ncoils_function ( (const char*) s.mb_str() , b ) . c_str() ;
 		mylog ( "SeqPlot::useNcoils" , "END ncoils_function" ) ;
-		wxString t ( (char*) x.c_str() , wxConvUTF8 ) ;
+		wxString t ( (const char*) x.c_str() , wxConvUTF8 ) ;
 		wxArrayString ta ;
 		explode ( _T("\n") , t , ta ) ;
 		for ( b = 0 ; b < s.length() ; b++ )

--- a/TAlignmentDialog.cpp
+++ b/TAlignmentDialog.cpp
@@ -50,7 +50,7 @@ TAlignmentDialog::TAlignmentDialog(wxWindow *parent, const wxString& title )
     h0->Add ( b , 1 , wxALL , 5 ) ;
     h0->Add ( c , 1 , wxALL , 5 ) ;
 
-    v0->Add ( nb , 1 , wxEXPAND|wxALL , 5 ) ;
+    v0->Add ( nb , 1 , wxEXPAND , 5 ) ;
     v0->Add ( h0 , 0 , wxCENTRE , 5 ) ;
     SetSizer ( v0 ) ;
 #else
@@ -139,9 +139,9 @@ void TAlignmentDialog::init_what ()
         }
 */
 
-    h0->Add ( v0 , 1 , wxEXPAND|wxALL , 5 ) ;    
+    h0->Add ( v0 , 1 , wxEXPAND , 5 ) ;    
     h0->Add ( v1 , 1 , wxALL , 5 ) ;    
-    h0->Add ( v2 , 1 , wxEXPAND|wxALL , 5 ) ;    
+    h0->Add ( v2 , 1 , wxEXPAND , 5 ) ;    
     vx->Add ( h0 , 1 , wxEXPAND ) ;
     vx->Add ( new wxStaticText ( p , -1 , txt("t_alignment_txt") ) , 0 , wxEXPAND|wxALIGN_CENTER_HORIZONTAL ) ;    
     p->SetSizer ( vx ) ;

--- a/TCalculator.cpp
+++ b/TCalculator.cpp
@@ -111,8 +111,8 @@ void TCalculator::initme ()
 
     SetMenuBar(menu_bar);
     
-    menu_bar->FindItem ( SEQ_PRINT ) -> SetText ( txt("m_print") ) ;
-    menu_bar->FindItem ( MDI_PRINT_REPORT ) -> SetText ( txt("m_print_preview") ) ;
+    menu_bar->FindItem ( SEQ_PRINT ) -> SetItemLabel ( txt("m_print") ) ;
+    menu_bar->FindItem ( MDI_PRINT_REPORT ) -> SetItemLabel ( txt("m_print_preview") ) ;
     
 
     nb = new wxNotebook ( this , -1 ) ;

--- a/TClone.h
+++ b/TClone.h
@@ -68,7 +68,7 @@ class TClone
 	void parseLines ( wxArrayString &v , char *t , long l ) ; ///< Breaks text into lines
 	void separateNames ( wxString &s1 , wxString &s2 ) ; ///< ???
 	int cmp ( const wxString &s1 , const wxString &s2 ) ; ///< String comparison
-	int a2i ( wxString &s ) { return atoi ( (char*) s.c_str() ) ; }  ///< Converts string to integer
+	int a2i ( wxString &s ) { return atoi ( (const char*) s.c_str() ) ; }  ///< Converts string to integer
 	
 	wxString filename , name , sequence , description ;
 	int size ; ///< Sequence length

--- a/TEliteLaChromLogDialog.cpp
+++ b/TEliteLaChromLogDialog.cpp
@@ -62,14 +62,14 @@ TEliteLaChromLogDialog::TEliteLaChromLogDialog ( wxWindow *parent, const wxStrin
     for ( a = 0 ; a < col_headers.GetCount() ; a++ )
         lines->InsertColumn (  a , col_headers[a] ) ;
 
-    h0->Add ( unique_dates , 1 , wxEXPAND|wxALL , 2 ) ;
-    h0->Add ( unique_users , 1 , wxEXPAND|wxALL , 2 ) ;
+    h0->Add ( unique_dates , 1 , wxEXPAND , 2 ) ;
+    h0->Add ( unique_users , 1 , wxEXPAND , 2 ) ;
     
-    h1->Add ( b_excel , 0 , wxEXPAND|wxALL , 2 ) ;
+    h1->Add ( b_excel , 0 , wxEXPAND , 2 ) ;
     
-    v0->Add ( h0 , 1 , wxEXPAND|wxALL , 2 ) ;
-    v0->Add ( lines , 1 , wxEXPAND|wxALL , 2 ) ;
-    v0->Add ( h1 , 0 , wxEXPAND|wxALL , 2 ) ;
+    v0->Add ( h0 , 1 , wxEXPAND , 2 ) ;
+    v0->Add ( lines , 1 , wxEXPAND , 2 ) ;
+    v0->Add ( h1 , 0 , wxEXPAND , 2 ) ;
     
     // Fill interface with data
     unique_users->Append ( txt("t_eld_all_users") ) ;

--- a/TGraphDisplay.cpp
+++ b/TGraphDisplay.cpp
@@ -971,8 +971,8 @@ void TGraphDisplay::OnSwapSides(wxCommandEvent &event)
 	{
 	if ( !old_scale ) return ;
 	old_scale->left = !old_scale->left ;
-	wxPaintEvent ev ;
-	OnPaint ( ev ) ;
+	Refresh();
+	Update();
 	}
 	
 void TGraphDisplay::DrawIntoBitmap ( wxBitmap &bmp )

--- a/TImageDisplay.cpp
+++ b/TImageDisplay.cpp
@@ -95,12 +95,12 @@ void TImageDisplay::initme ()
     cb = new wxCheckBox ( this , IV_CB , txt("img_show_text" ) ) ;
     invert = new wxCheckBox ( this , IV_CB_INVERT , txt("t_invert" ) ) ;
     
-    v0->Add ( bu , 0 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( lb , 1 , wxEXPAND|wxALL , 5 ) ;
+    v0->Add ( bu , 0 , wxEXPAND , 5 ) ;
+    v0->Add ( lb , 1 , wxEXPAND , 5 ) ;
     
     h1->Add ( cb , 0 , wxEXPAND , 5 ) ;
     h1->Add ( invert , 0 , wxEXPAND , 5 ) ;
-    v0->Add ( h1 , 0 , wxEXPAND|wxALL , 5 ) ;
+    v0->Add ( h1 , 0 , wxEXPAND , 5 ) ;
     
     h0->Add ( v0 , 0 , wxEXPAND , 5 ) ;
     h0->Add ( right , 1 , wxEXPAND , 5 ) ;
@@ -113,7 +113,7 @@ void TImageDisplay::initme ()
        myapp()->frame->addTool ( toolbar , MDI_COPY ) ;
        myapp()->frame->addDefaultTools ( toolbar ) ;
        toolbar->Realize() ;
-       vx->Add ( toolbar , 0 , wxEXPAND|wxBOTTOM , 2 ) ;
+       vx->Add ( toolbar , 0 , wxEXPAND , 2 ) ;
        }
 
     vx->Add ( h0 , 1 , wxEXPAND , 5 ) ;

--- a/TImageDisplay.cpp
+++ b/TImageDisplay.cpp
@@ -310,7 +310,7 @@ void TMyImagePanel::OnDraw(wxDC& pdc)
 
     if ( invert )
     	{
-        int lf = pdc.GetLogicalFunction() ;
+        wxRasterOperationMode lf = pdc.GetLogicalFunction() ;
         pdc.SetLogicalFunction ( wxINVERT ) ;
         pdc.SetBrush ( *wxWHITE_BRUSH ) ;
         pdc.SetPen ( *wxWHITE_PEN ) ;

--- a/TItemEditDialog.cpp
+++ b/TItemEditDialog.cpp
@@ -79,9 +79,9 @@ TItemEditDialog::TItemEditDialog ( wxWindow *parent, const wxString& title ,
    h1->Add ( button_cancel , 0 , wxEXPAND ) ;
 #endif
    
-   v0->Add ( rb , 0 , wxEXPAND|wxALL , 5 ) ;
-   v0->Add ( h0 , 0 , wxEXPAND|wxALL , 5 ) ;
-   v0->Add ( lb , 1 , wxEXPAND|wxALL , 5 ) ;
+   v0->Add ( rb , 0 , wxEXPAND , 5 ) ;
+   v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
+   v0->Add ( lb , 1 , wxEXPAND , 5 ) ;
    v0->Add ( h1 , 0 , wxCENTER|wxALL , 5 ) ;
       
    button_OK->SetDefault() ;

--- a/TLigationDialog.cpp
+++ b/TLigationDialog.cpp
@@ -44,9 +44,9 @@ void TLigationDialog::init ()
     l_sources = new wxCheckListBox ( this , LD_SOURCES ) ;
     l_targets = new wxCheckListBox ( this , LD_TARGETS ) ;
 	v1a->Add ( new wxStaticText ( this , -1 , txt("frag2lig") ) , 0 , wxEXPAND ) ;
-	v1a->Add ( l_sources , 1 , wxEXPAND|wxTOP , 5 ) ;
+	v1a->Add ( l_sources , 1 , wxEXPAND , 5 ) ;
 	v1b->Add ( new wxStaticText ( this , -1 , txt("what2create") ) , 0 , wxEXPAND ) ;
-	v1b->Add ( l_targets , 1 , wxEXPAND|wxTOP , 5 ) ;
+	v1b->Add ( l_targets , 1 , wxEXPAND , 5 ) ;
 	h1->Add ( v1a , 1 , wxEXPAND ) ;
 	h1->Add ( v1b , 1 , wxEXPAND ) ;
 	
@@ -57,8 +57,8 @@ void TLigationDialog::init ()
 	h0->Add ( new wxButton ( this , LD_CANCEL , txt("b_cancel") ) , 0 ) ;
 	
 	v0->Add ( h1 , 1 , wxEXPAND ) ;
-	v0->Add ( message , 0 , wxEXPAND|wxTOP , 5 ) ;
-	v0->Add ( h0 , 0 , wxEXPAND|wxTOP , 5 ) ;
+	v0->Add ( message , 0 , wxEXPAND , 5 ) ;
+	v0->Add ( h0 , 0 , wxEXPAND , 5 ) ;
 
     this->SetSizer ( v0 ) ;
 //    v0->Fit ( this ) ;

--- a/TPhyloTree.cpp
+++ b/TPhyloTree.cpp
@@ -3,7 +3,6 @@
 BEGIN_EVENT_TABLE(TPhyloTree, MyChildBase)
     EVT_CLOSE(ChildBase::OnClose)
     EVT_SET_FOCUS(ChildBase::OnFocus)
-    EVT_SIZE(ChildBase::OnSize)
     EVT_CHECKBOX(PHYLIP_DIRECT_LINES,TPhyloTree::OnDirectLines)
     EVT_LISTBOX(PHYLIP_TREE_LIST,TPhyloTree::OnTreeList)
     EVT_MENU(MDI_FILE_SAVE,TPhyloTree::OnFileSave)

--- a/TProteolysis.cpp
+++ b/TProteolysis.cpp
@@ -119,31 +119,31 @@ TProteolysis::TProteolysis(TAminoAcids *_parent, const wxString& title )
 	wxBoxSizer *vr = new wxBoxSizer ( wxVERTICAL ) ;
 	wxBoxSizer *vg = new wxBoxSizer ( wxVERTICAL ) ;
 	
-	va->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_separate") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	va->Add ( sep_fragments , 2 , wxEXPAND|wxALL , 5 ) ;
-	va->Add ( sep_num_prot , 0 , wxEXPAND|wxALL , 5 ) ;
-	va->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_auto_results") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	va->Add ( sep_results , 2 , wxEXPAND|wxALL , 5 ) ;
-	va->Add ( sep_desc , 1 , wxEXPAND|wxALL , 5 ) ;
+	va->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_separate") ) , 0 , wxEXPAND , 5 ) ;
+	va->Add ( sep_fragments , 2 , wxEXPAND , 5 ) ;
+	va->Add ( sep_num_prot , 0 , wxEXPAND , 5 ) ;
+	va->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_auto_results") ) , 0 , wxEXPAND , 5 ) ;
+	va->Add ( sep_results , 2 , wxEXPAND , 5 ) ;
+	va->Add ( sep_desc , 1 , wxEXPAND , 5 ) ;
 
-	vl->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_proteases") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	vl->Add ( proteases , 1 , wxEXPAND|wxALL , 5 ) ;
-	vl->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_skip") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	vl->Add ( ignore , 1 , wxEXPAND|wxALL , 5 ) ;
+	vl->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_proteases") ) , 0 , wxEXPAND , 5 ) ;
+	vl->Add ( proteases , 1 , wxEXPAND , 5 ) ;
+	vl->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_skip") ) , 0 , wxEXPAND , 5 ) ;
+	vl->Add ( ignore , 1 , wxEXPAND , 5 ) ;
 
-	h3->Add ( new wxButton ( this , PRO_FRAGMENTS_ALL , txt("b_all") ) , 0 , wxALL|wxEXPAND , 2 ) ;
-	h3->Add ( new wxButton ( this , PRO_FRAGMENTS_NONE , txt("b_none") ) , 0 , wxALL|wxEXPAND , 2 ) ;
+	h3->Add ( new wxButton ( this , PRO_FRAGMENTS_ALL , txt("b_all") ) , 0 , wxEXPAND , 2 ) ;
+	h3->Add ( new wxButton ( this , PRO_FRAGMENTS_NONE , txt("b_none") ) , 0 , wxEXPAND , 2 ) ;
 
-	vr->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_cuts") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( cuts , 1 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( partial_digestion , 0 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_results") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( results , 1 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( sortresults , 0 , wxEXPAND|wxALL , 5 ) ;
-	vr->Add ( h3 , 0 , wxEXPAND|wxALL , 5 ) ;
+	vr->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_cuts") ) , 0 , wxEXPAND , 5 ) ;
+	vr->Add ( cuts , 1 , wxEXPAND , 5 ) ;
+	vr->Add ( partial_digestion , 0 , wxEXPAND , 5 ) ;
+	vr->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_results") ) , 0 , wxEXPAND , 5 ) ;
+	vr->Add ( results , 1 , wxEXPAND , 5 ) ;
+	vr->Add ( sortresults , 0 , wxEXPAND , 5 ) ;
+	vr->Add ( h3 , 0 , wxEXPAND , 5 ) ;
 	
-	vg->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_gel") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	vg->Add ( gel , 1 , wxEXPAND|wxALL , 5 ) ;
+	vg->Add ( new wxStaticText ( this , -1 , txt("t_proteolysis_gel") ) , 0 , wxEXPAND , 5 ) ;
+	vg->Add ( gel , 1 , wxEXPAND , 5 ) ;
 
 	
 	h0->Add ( va , 2 , wxEXPAND ) ;
@@ -151,17 +151,17 @@ TProteolysis::TProteolysis(TAminoAcids *_parent, const wxString& title )
 	h0->Add ( vr , 2 , wxEXPAND ) ;
 	h0->Add ( vg , 1 , wxEXPAND ) ;
 
-	h1->Add ( create_fragments , 0 , wxALL|wxEXPAND , 2 ) ;
-	h1->Add ( create_labels , 0 , wxALL|wxEXPAND , 2 ) ;
-	h1->Add ( use_proteases , 0 , wxALL|wxEXPAND , 2 ) ;
-	h1->Add ( show_uncut , 0 , wxALL|wxEXPAND , 2 ) ;
-	h1->Add ( new wxButton ( this , PRO_CREATE_REPORT , txt("b_pro_report") ) , 0 , wxALL|wxEXPAND , 2 ) ;
+	h1->Add ( create_fragments , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( create_labels , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( use_proteases , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( show_uncut , 0 , wxEXPAND , 2 ) ;
+	h1->Add ( new wxButton ( this , PRO_CREATE_REPORT , txt("b_pro_report") ) , 0 , wxEXPAND , 2 ) ;
 
-	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 2 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( new wxButton ( this , POD_OK , txt("b_ok") ) , 1 , wxALL|wxEXPAND , 2 ) ;
-	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 1 , wxEXPAND|wxALL , 2 ) ;
-	h2->Add ( new wxButton ( this , POD_CANCEL , txt("b_cancel") ) , 1 , wxALL|wxEXPAND , 2 ) ;
-	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 2 , wxEXPAND|wxALL , 2 ) ;
+	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 2 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxButton ( this , POD_OK , txt("b_ok") ) , 1 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 1 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxButton ( this , POD_CANCEL , txt("b_cancel") ) , 1 , wxEXPAND , 2 ) ;
+	h2->Add ( new wxStaticText ( this , -1 , txt("") ) , 2 , wxEXPAND , 2 ) ;
 	
 	v0->Add ( h0 , 1 , wxEXPAND ) ;
 	v0->Add ( h1 , 0 , wxEXPAND ) ;

--- a/TRestrictionEditor.cpp
+++ b/TRestrictionEditor.cpp
@@ -385,7 +385,7 @@ void TRestrictionEditor::res_ll_act ( wxListEvent &event )
     wxString s = el->GetItemText ( i ) ;
     TRestrictionEnzyme *e = myapp()->frame->LS->getRestrictionEnzyme ( s ) ;
     TEnzymeDialog ed ( this , s , wxPoint(-1,-1) , wxSize(600,400) , 
-					  wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL ) ;
+					  wxDEFAULT_DIALOG_STYLE|wxCENTRE ) ;
     ed.initme ( e , true ) ;
     ed.ShowModal() ;
 }

--- a/TRestrictionEditor.cpp
+++ b/TRestrictionEditor.cpp
@@ -176,7 +176,7 @@ void TRestrictionEditor::initRestrictionPage ()
     nfstv->SetSize ( 70 , th * 2 ) ;
     h1d->Add ( nfstv , 0 , wxALL|wxALIGN_CENTER_VERTICAL , 5 ) ;
     h1d->Add ( new wxStaticText ( this , -1 , txt("base pairs.") ) , 
-			  1 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
+			  1 , wxEXPAND , 5 ) ;
 	
 	
 	wxBoxSizer *v3a = new wxBoxSizer ( wxVERTICAL ) ;
@@ -240,9 +240,9 @@ void TRestrictionEditor::initRestrictionPage ()
     v2b->Add ( h1e , 1 , wxEXPAND , 5 ) ;
     v2b->Add ( h1f , 1 , wxEXPAND , 5 ) ;
 	
-    h1->Add ( v2a , 1 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( v2b , 1 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( v2c , 1 , wxEXPAND|wxALL , 5 ) ;
+    h1->Add ( v2a , 1 , wxEXPAND , 5 ) ;
+    h1->Add ( v2b , 1 , wxEXPAND , 5 ) ;
+    h1->Add ( v2c , 1 , wxEXPAND , 5 ) ;
     
     // "This enzyme cuts" list
     rsl = new wxListCtrl ( this , -1 , wxDefaultPosition , wxDefaultSize ,
@@ -262,8 +262,8 @@ void TRestrictionEditor::initRestrictionPage ()
 	
     rsl->SetSize ( w/3 , h/3 ) ;
 	
-    h2->Add ( rsl , 1 , wxEXPAND|wxALL , 5 ) ;
-    h2->Add ( rsl2 , 1 , wxEXPAND|wxALL , 5 ) ;
+    h2->Add ( rsl , 1 , wxEXPAND , 5 ) ;
+    h2->Add ( rsl2 , 1 , wxEXPAND , 5 ) ;
     
     v1->Add ( h1 , 1 , wxEXPAND , 5 ) ;
     v1->Add ( h2 , 1 , wxEXPAND , 5 ) ;

--- a/TRestrictionIdentifier.cpp
+++ b/TRestrictionIdentifier.cpp
@@ -66,27 +66,27 @@ void TRestrictionIdentifier::initme ()
     group_list = new wxChoice ( this , RI_GROUP ) ;
     enzymes_list = new wxListBox ( this , RI_ENZYMES_LIST ) ;
 
-    h1->Add ( new wxStaticText(this,-1,txt("t_minumum")+_T(" ")) , 0 , wxEXPAND|wxALL , 2 ) ;
-    h1->Add ( bp_list , 0 , wxEXPAND|wxALL , 2 ) ;
-    h1->Add ( new wxStaticText(this,-1,txt("t_bp")) , 0 , wxEXPAND|wxALL , 2 ) ;
+    h1->Add ( new wxStaticText(this,-1,txt("t_minumum")+_T(" ")) , 0 , wxEXPAND , 2 ) ;
+    h1->Add ( bp_list , 0 , wxEXPAND , 2 ) ;
+    h1->Add ( new wxStaticText(this,-1,txt("t_bp")) , 0 , wxEXPAND , 2 ) ;
 
-    h2->Add ( new wxStaticText(this,-1,txt("t_minumum")+_T(" ")) , 0 , wxEXPAND|wxALL , 2 ) ;
-    h2->Add ( percent_list , 0 , wxEXPAND|wxALL , 2 ) ;
-    h2->Add ( new wxStaticText(this,-1,_T("%")) , 0 , wxEXPAND|wxALL , 2 ) ;
+    h2->Add ( new wxStaticText(this,-1,txt("t_minumum")+_T(" ")) , 0 , wxEXPAND , 2 ) ;
+    h2->Add ( percent_list , 0 , wxEXPAND , 2 ) ;
+    h2->Add ( new wxStaticText(this,-1,_T("%")) , 0 , wxEXPAND , 2 ) ;
     
-//    h3->Add ( new wxStaticText(this,-1,txt("enzyme_groups")+_T(" ")) , 0 , wxEXPAND|wxALL , 2 ) ;
-//    h3->Add ( group_list , 0 , wxEXPAND|wxALL , 2 ) ;
+//    h3->Add ( new wxStaticText(this,-1,txt("enzyme_groups")+_T(" ")) , 0 , wxEXPAND , 2 ) ;
+//    h3->Add ( group_list , 0 , wxEXPAND , 2 ) ;
     
-    v->Add ( new wxStaticText(this,-1,txt("band_difference")) , 0 , wxEXPAND|wxALL , 2 ) ;
-    v->Add ( h1 , 0 , wxEXPAND|wxALL , 2 ) ;
-    v->Add ( h2 , 0 , wxEXPAND|wxALL , 2 ) ;
-//    v->Add ( h3 , 0 , wxEXPAND|wxALL , 5 ) ;
+    v->Add ( new wxStaticText(this,-1,txt("band_difference")) , 0 , wxEXPAND , 2 ) ;
+    v->Add ( h1 , 0 , wxEXPAND , 2 ) ;
+    v->Add ( h2 , 0 , wxEXPAND , 2 ) ;
+//    v->Add ( h3 , 0 , wxEXPAND , 5 ) ;
 
-    v->Add ( new wxStaticText(this,-1,txt("enzyme_groups")) , 0 , wxEXPAND|wxALL , 2 ) ;
-    v->Add ( group_list , 0 , wxEXPAND|wxALL , 2 ) ;
+    v->Add ( new wxStaticText(this,-1,txt("enzyme_groups")) , 0 , wxEXPAND , 2 ) ;
+    v->Add ( group_list , 0 , wxEXPAND , 2 ) ;
 
-    v->Add ( enzymes_list , 2 , wxEXPAND|wxALL , 2 ) ;
-    v->Add ( dna_list , 1 , wxEXPAND|wxALL , 2 ) ;
+    v->Add ( enzymes_list , 2 , wxEXPAND , 2 ) ;
+    v->Add ( dna_list , 1 , wxEXPAND , 2 ) ;
 
     main->Add ( v , 0 , wxEXPAND , 2 ) ;
     main->Add ( right , 1 , wxEXPAND , 2 ) ;

--- a/TSequencingAssistantDialog.cpp
+++ b/TSequencingAssistantDialog.cpp
@@ -20,12 +20,12 @@ TSequencingAssistantDialog::TSequencingAssistantDialog (wxWindow *parent , const
 	abi2 = new wxChoice ( this , SAD_ABI2 ) ;
 	
 	// Sequence/sequencing data dropdown boxes
-	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_sequence") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1a->Add ( sequence , 1 , wxEXPAND|wxALL , 5 ) ;
-	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_abi1") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1a->Add ( abi1 , 1 , wxEXPAND|wxALL , 5 ) ;
-	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_abi2") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1a->Add ( abi2 , 1 , wxEXPAND|wxALL , 5 ) ;
+	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_sequence") ) , 0 , wxEXPAND , 5 ) ;
+	h1a->Add ( sequence , 1 , wxEXPAND , 5 ) ;
+	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_abi1") ) , 0 , wxEXPAND , 5 ) ;
+	h1a->Add ( abi1 , 1 , wxEXPAND , 5 ) ;
+	h1a->Add ( new wxStaticText ( this , -1 , txt("t_sad_abi2") ) , 0 , wxEXPAND , 5 ) ;
+	h1a->Add ( abi2 , 1 , wxEXPAND , 5 ) ;
 
 	// OK/Cancel
     ok = new wxButton ( this , wxID_OK , txt("b_ok") ) ;
@@ -35,8 +35,8 @@ TSequencingAssistantDialog::TSequencingAssistantDialog (wxWindow *parent , const
 	
 	// Initial help text
     v0->Add ( new wxStaticText ( this , -1 , txt("t_sad_text") , wxDefaultPosition , wxSize(400,60) , wxALIGN_CENTRE ) , 
-               0 , wxEXPAND|wxALL , 5 ) ;
-	v0->Add ( h1a , 0 , wxEXPAND|wxALL , 5 ) ;
+               0 , wxEXPAND , 5 ) ;
+	v0->Add ( h1a , 0 , wxEXPAND , 5 ) ;
 	v0->Add ( h2 , 0 , wxCENTER|wxALL , 5 ) ;
 	
 	// Initialize dropdown boxes

--- a/TSilmutDialog.cpp
+++ b/TSilmutDialog.cpp
@@ -48,17 +48,17 @@ TSilmutDialog::TSilmutDialog ( wxWindow *parent , const wxString &s , int _mode 
                             wxDefaultPosition , wxSize ( MYSPINBOXSIZE , -1 ) ,
                             wxSP_ARROW_KEYS , 0 , 9 , 2 ) ;
     allow_cut_removal = new wxCheckBox ( this , PD_SILMUT_ACR , txt("t_silmut_allow_cut_removal") ) ;
-    h0->Add ( st , 0 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( lim_xhg , 0 , wxEXPAND|wxALL , 5 ) ;
-	h0->Add ( allow_cut_removal , 0 , wxEXPAND|wxALL , 5 ) ;
+    h0->Add ( st , 0 , wxEXPAND , 5 ) ;
+	h0->Add ( lim_xhg , 0 , wxEXPAND , 5 ) ;
+	h0->Add ( allow_cut_removal , 0 , wxEXPAND , 5 ) ;
 	
 	// Max cuts
     lim_max = new wxSpinCtrl ( this , PD_SILMUT_MAX_CUT , _T("5") ,
                             wxDefaultPosition , wxSize ( MYSPINBOXSIZE , -1 ) ,
                             wxSP_ARROW_KEYS , 0 , 99 , 5 ) ;
-    h1->Add ( new wxStaticText ( this , -1 , txt("t_silmut_max_cut1") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-	h1->Add ( lim_max , 0 , wxEXPAND|wxALL , 5 ) ;
-    h1->Add ( new wxStaticText ( this , -1 , txt("t_silmut_max_cut2") ) , 0 , wxEXPAND|wxALL , 5 ) ;
+    h1->Add ( new wxStaticText ( this , -1 , txt("t_silmut_max_cut1") ) , 0 , wxEXPAND , 5 ) ;
+	h1->Add ( lim_max , 0 , wxEXPAND , 5 ) ;
+    h1->Add ( new wxStaticText ( this , -1 , txt("t_silmut_max_cut2") ) , 0 , wxEXPAND , 5 ) ;
 
 	status = new wxStaticText ( this , -1 , _T("") ) ;
 	status->Hide() ;
@@ -77,14 +77,14 @@ TSilmutDialog::TSilmutDialog ( wxWindow *parent , const wxString &s , int _mode 
     if ( mode == M_WHATCUTS ) egr->SetStringSelection ( txt("All") ) ;
     else if ( mode == M_SILMUT ) egr->SetStringSelection ( txt("Current") ) ;
     
-    h2->Add ( egr , 0 , wxEXPAND|wxALL , 5 ) ;
-    h2->Add ( new wxButton ( this , PD_SILMUT_OK , txt("b_ok") ) , 0 , wxEXPAND|wxALL , 5 ) ;
-    h2->Add ( new wxButton ( this , PD_SILMUT_CANCEL , txt("b_cancel") ) , 0 , wxEXPAND|wxALL , 5 ) ;
+    h2->Add ( egr , 0 , wxEXPAND , 5 ) ;
+    h2->Add ( new wxButton ( this , PD_SILMUT_OK , txt("b_ok") ) , 0 , wxEXPAND , 5 ) ;
+    h2->Add ( new wxButton ( this , PD_SILMUT_CANCEL , txt("b_cancel") ) , 0 , wxEXPAND , 5 ) ;
     
     if ( mut_pos > -1 ) // I have no idea what this is for...
         {
         mut = new wxChoice ( this , PD_SILMUT_EGR ) ;
-        h2->Add ( mut , 0 , wxEXPAND|wxALL , 5 ) ;
+        h2->Add ( mut , 0 , wxEXPAND , 5 ) ;
         }
         
 	// List

--- a/TStorage.cpp
+++ b/TStorage.cpp
@@ -272,7 +272,7 @@ TSQLresult TStorage::getObjectSqlite3 ( const wxString &query )
         } while ( rc == SQLITE_BUSY ) ;
     
     ierror = e ? 1 : 0 ;
-    if ( e ) error = wxString ( _T("An error has occurred when executing query ") + query , wxConvUTF8 ) ;
+    if ( e ) error = _T("An error has occurred when executing query ") + query;
     else error = _T("Alles OK") ;
 
     sqlite3_close ( db ) ;
@@ -531,7 +531,7 @@ void TStorage::replaceTable ( wxString table , wxArrayString &f , wxArrayString 
         s1 = s2 = _T("") ;
         for ( b = 0 ; b < f.GetCount() ; b++ )
            {
-           int id = r[(char*)f[b].c_str()] ;
+           int id = r[(const char*)f[b].c_str()] ;
            if ( id > -1 ) sqlAdd ( s1 , s2 , f[b] , r[a][id] ) ;
            else sqlAdd ( s1 , s2 , f[b] , _T("") ) ;
            }

--- a/TStoreAllDialog.cpp
+++ b/TStoreAllDialog.cpp
@@ -32,24 +32,24 @@ TStoreAllDialog::TStoreAllDialog ( wxWindow *_parent , const wxString& title )
    force_db = new wxCheckBox ( this , -1 , txt("t_sad_force_database") ) ;
    auto_overwrite = new wxCheckBox ( this , -1 , txt("t_sad_auto_overwrite") ) ;
 
-   h0->Add ( b_all , 1 , wxEXPAND|wxALL , 2 ) ;
-   h0->Add ( b_none , 1 , wxEXPAND|wxALL , 2 ) ;
-   h0->Add ( b_invert , 1 , wxEXPAND|wxALL , 2 ) ;
+   h0->Add ( b_all , 1 , wxEXPAND , 2 ) ;
+   h0->Add ( b_none , 1 , wxEXPAND , 2 ) ;
+   h0->Add ( b_invert , 1 , wxEXPAND , 2 ) ;
    
-   h1->Add ( b_ok , 1 , wxEXPAND|wxALL , 2 ) ;
-   h1->Add ( b_cancel , 1 , wxEXPAND|wxALL , 2 ) ;
+   h1->Add ( b_ok , 1 , wxEXPAND , 2 ) ;
+   h1->Add ( b_cancel , 1 , wxEXPAND , 2 ) ;
    
-   h2->Add ( auto_overwrite , 0 , wxEXPAND|wxALL , 2 ) ;   
-   h2->Add ( force_db , 0 , wxEXPAND|wxALL , 2 ) ;
+   h2->Add ( auto_overwrite , 0 , wxEXPAND , 2 ) ;   
+   h2->Add ( force_db , 0 , wxEXPAND , 2 ) ;
 
-   h3->Add ( new wxStaticText ( this , -1 , _T("t_default_database") ) , 0 , wxEXPAND|wxALL , 2 ) ;
-   h3->Add ( database , 1 , wxEXPAND|wxALL , 2 ) ;
+   h3->Add ( new wxStaticText ( this , -1 , _T("t_default_database") ) , 0 , wxEXPAND , 2 ) ;
+   h3->Add ( database , 1 , wxEXPAND , 2 ) ;
    
-   v0->Add ( list , 1 , wxEXPAND|wxALL , 2 ) ;
-   v0->Add ( h3 , 0 , wxEXPAND|wxALL , 2 ) ;
-   v0->Add ( h2 , 0 , wxEXPAND|wxALL , 2 ) ;
-   v0->Add ( h0 , 0 , wxEXPAND|wxALL , 2 ) ;
-   v0->Add ( h1 , 0 , wxEXPAND|wxALL , 2 ) ;
+   v0->Add ( list , 1 , wxEXPAND , 2 ) ;
+   v0->Add ( h3 , 0 , wxEXPAND , 2 ) ;
+   v0->Add ( h2 , 0 , wxEXPAND , 2 ) ;
+   v0->Add ( h0 , 0 , wxEXPAND , 2 ) ;
+   v0->Add ( h1 , 0 , wxEXPAND , 2 ) ;
    
    PopulateList() ;
    database->SetStringSelection ( defdb ) ;

--- a/TVectorEditor.cpp
+++ b/TVectorEditor.cpp
@@ -400,7 +400,7 @@ void TVectorEditor::newProtease ( wxCommandEvent &ev )
     e->setCut ( 0 ) ;
     e->setOverlap ( 0 ) ;
     TEnzymeDialog ed ( this , txt("t_new_protease") , wxPoint(-1,-1) , wxSize(600,400) , 
-                    wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL ) ;
+                    wxDEFAULT_DIALOG_STYLE|wxCENTRE ) ;
     ed.initme ( e ) ;
     if ( ed.ShowModal() == wxID_OK )
        {

--- a/TVectorEditorEnzymes.cpp
+++ b/TVectorEditorEnzymes.cpp
@@ -54,27 +54,27 @@ void TVectorEditor::initPanEnzym ()
     v1->Add ( listCE , 1 , wxEXPAND , 5 ) ;
 
     v2->Add ( new wxStaticText ( panEnzym , -1 , _T("") ) , 0 , wxEXPAND , 5 ) ;
-    v2->Add ( b_addgr , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b_atg , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b_asng , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b_dg , 0 , wxEXPAND|wxALL , 5 ) ;
-    if ( b1 ) v2->Add ( b1 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b2 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( delete_enzyme_button , 0 , wxEXPAND|wxALL , 5 ) ;
+    v2->Add ( b_addgr , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b_atg , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b_asng , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b_dg , 0 , wxEXPAND , 5 ) ;
+    if ( b1 ) v2->Add ( b1 , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b2 , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( delete_enzyme_button , 0 , wxEXPAND , 5 ) ;
     v2->Add ( new wxStaticText ( panEnzym , -1 , _T("") ) , 0 , wxEXPAND , 5 ) ;
-    v2->Add ( b3 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b4 , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b_dfg , 0 , wxEXPAND|wxALL , 5 ) ;
-    v2->Add ( b_import_rebase , 0 , wxEXPAND|wxALL , 5 ) ;
+    v2->Add ( b3 , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b4 , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b_dfg , 0 , wxEXPAND , 5 ) ;
+    v2->Add ( b_import_rebase , 0 , wxEXPAND , 5 ) ;
     
     v3->Add ( tGR , 0 , wxEXPAND , 5 ) ;
     v3->Add ( listGroups , 1 , wxEXPAND , 5 ) ;
     v3->Add ( tGE , 0 , wxEXPAND , 5 ) ;
     v3->Add ( listGE , 3 , wxEXPAND , 5 ) ;
     
-    h1->Add ( v1 , 1 , wxEXPAND|wxALL , 5 ) ;
+    h1->Add ( v1 , 1 , wxEXPAND , 5 ) ;
     h1->Add ( v2 , 0 , wxEXPAND , 5 ) ;
-    h1->Add ( v3 , 1 , wxEXPAND|wxALL , 5 ) ;
+    h1->Add ( v3 , 1 , wxEXPAND , 5 ) ;
 
     panEnzym->SetSizer ( h1 ) ;
     h1->Fit ( panEnzym ) ;

--- a/TVectorEditorEnzymes.cpp
+++ b/TVectorEditorEnzymes.cpp
@@ -116,7 +116,7 @@ void TVectorEditor::enzymeListDlbClick ( wxCommandEvent &ev )
             wxString s = lb->GetString ( vi[k] ) ;
             TRestrictionEnzyme *e = myapp()->frame->LS->getRestrictionEnzyme ( s ) ;
             TEnzymeDialog ed ( this , s , wxPoint(-1,-1) , wxSize(600,400) , 
-                            wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL ) ;
+                            wxDEFAULT_DIALOG_STYLE|wxCENTRE ) ;
             ed.initme ( e ) ;
             if ( ed.ShowModal() == wxID_OK )
                {
@@ -149,7 +149,7 @@ void TVectorEditor::enzymeListDlbClick ( wxCommandEvent &ev )
         wxString s = lb->GetString ( vi[0] ) ;
         TRestrictionEnzyme *e = myapp()->frame->LS->getRestrictionEnzyme ( s ) ;
         TEnzymeDialog ed ( this , s , wxPoint(-1,-1) , wxSize(600,400) , 
-                        wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL ) ;
+                        wxDEFAULT_DIALOG_STYLE|wxCENTRE ) ;
         ed.initme ( e ) ;
         ed.ShowModal() ;
         }
@@ -335,7 +335,7 @@ void TVectorEditor::newEnzyme ( wxCommandEvent &ev )
     e->setCut ( 0 ) ;
     e->setOverlap ( 0 ) ;
     TEnzymeDialog ed ( this , txt("t_new_enzyme") , wxPoint(-1,-1) , wxSize(600,400) , 
-                    wxDEFAULT_DIALOG_STYLE|wxCENTRE|wxDIALOG_MODAL ) ;
+                    wxDEFAULT_DIALOG_STYLE|wxCENTRE ) ;
     ed.initme ( e ) ;
     if ( ed.ShowModal() == wxID_OK )
        {

--- a/TVectorEditorItems.cpp
+++ b/TVectorEditorItems.cpp
@@ -183,9 +183,9 @@ void TVectorEditor::initPanItem ()
 			   wxDefaultPosition , wxDefaultSize ,
 			   4 , vt , wxRA_SPECIFY_COLS ) ;
 
-    v1->Add ( h0a , 0 , wxEXPAND|wxALL , 2 ) ;
-    v1->Add ( h1a , 0 , wxEXPAND|wxALL , 2 ) ;
-    v1->Add ( idesc , 1 , wxEXPAND|wxALL , 2 ) ;
+    v1->Add ( h0a , 0 , wxEXPAND , 2 ) ;
+    v1->Add ( h1a , 0 , wxEXPAND , 2 ) ;
+    v1->Add ( idesc , 1 , wxEXPAND , 2 ) ;
 
     v2->Add ( h0b ) ;
     v2->Add ( h1b ) ;
@@ -204,8 +204,8 @@ void TVectorEditor::initPanItem ()
     h2->Add ( v1 , 1, wxEXPAND ) ;
     h2->Add ( v2 , 0 , 0 ) ;
 
-    v0->Add ( items , 1 , wxEXPAND|wxALL , 5 ) ;
-    v0->Add ( h2 , 1 , wxEXPAND|wxALL , 5 ) ;
+    v0->Add ( items , 1 , wxEXPAND , 5 ) ;
+    v0->Add ( h2 , 1 , wxEXPAND , 5 ) ;
     panItem->SetSizer ( v0 ) ;
     nb->AddPage ( panItem , txt("t_vec_item") ) ;
     }

--- a/TVirtualGel.cpp
+++ b/TVirtualGel.cpp
@@ -110,11 +110,11 @@ void TVirtualGel::initme ()
 
 
 /*
-	hs->Add ( cb_label , 0 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
-	hs->Add ( new wxStaticText ( this , -1 , txt("t_vg_concentration") ) , 0 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
-	hs->Add ( ch_percent , 0 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
-	hs->Add ( new wxStaticText ( this , -1 , txt("t_vg_marker") ) , 0 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
-	hs->Add ( ch_marker , 0 , wxEXPAND|wxALIGN_CENTER_VERTICAL , 5 ) ;
+	hs->Add ( cb_label , 0 , wxEXPAND , 5 ) ;
+	hs->Add ( new wxStaticText ( this , -1 , txt("t_vg_concentration") ) , 0 , wxEXPAND , 5 ) ;
+	hs->Add ( ch_percent , 0 , wxEXPAND , 5 ) ;
+	hs->Add ( new wxStaticText ( this , -1 , txt("t_vg_marker") ) , 0 , wxEXPAND , 5 ) ;
+	hs->Add ( ch_marker , 0 , wxEXPAND , 5 ) ;
 */
 	
 	wxBoxSizer *vs = new wxBoxSizer ( wxVERTICAL ) ;

--- a/TVirtualGel.cpp
+++ b/TVirtualGel.cpp
@@ -8,7 +8,6 @@
 BEGIN_EVENT_TABLE(TVirtualGel, MyChildBase)
     EVT_CLOSE(ChildBase::OnClose)
     EVT_SET_FOCUS(ChildBase::OnFocus)
-    EVT_SIZE(TVirtualGel::OnSize)
     
     EVT_CHOICE(VG_PERCENT,TVirtualGel::OnPercent)
     EVT_CHOICE(VG_MARKER,TVirtualGel::OnMarker)

--- a/TXMLfile.cpp
+++ b/TXMLfile.cpp
@@ -221,7 +221,7 @@ void TXMLfile::readGBqualifiers ( TVectorItem &i , TiXmlNode *n )
         {
         char u[100] ;
         sprintf ( u , "short_itemtype%d" , i.getType() ) ;
-        i.name = wxString ( txt(u) , wxConvUTF8 ) ;
+        i.name = txt(u);
         wxString d2 = i.desc ;
         int k = d2.find ( _T("\n") ) ;
         if ( k > -1 ) d2.erase ( k ) ;

--- a/main.cpp
+++ b/main.cpp
@@ -253,7 +253,7 @@ bool MyApp::OnInit()
 	if ( wxGetEnv ( _T("COILSDIR") , NULL ) ) wxUnsetEnv ( _T("COILSDIR") ) ;
 	wxSetEnv ( _T("COILSDIR") , homedir ) ;
 #else
-	putenv ( (char*) ncoilsdir.c_str() ) ;
+	setenv ( "COILSDIR" , homedir.c_str() , 1 ) ;
 #endif	
 
 	


### PR DESCRIPTION
    Avoid joint use of wxEXPAND flag with others
    
    wxEXPAND extends in all directions, extra flags like
    wxTOP, wxBOTTOM, wxLEFT, wxRIGHT, or wxALL are considered
    redundant and there is a runtime check by wxWidgets about it.
    The dialog boxes still look just fine with this patch applied.
