### PR TITLE
Fixing clang warning indicating operator precedence issue

### DIFF
--- a/OnlineTools.cpp
+++ b/OnlineTools.cpp
@@ -274,7 +274,8 @@ void TOnlineTools::do_neb_cutter ()
     url = _T("http://tools.neb.com/NEBcutter2/enzcut.php?") ;
     url += _T("username=") + get_fasta_name() ;
     url += _T("&min_orf=100") ;
-    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
+    url += _T("&circular=") ;
+    url += child->vec->isLinear() ? _T("0") : _T("1") ;
     url += _T("&enz_suppl=1") ;
     url += _T("&sequence=") + sequence ;
     wxExecute ( myapp()->getHTMLCommand ( url ) ) ;


### PR DESCRIPTION
With g++ it all compiles happily on Linux, but the mac using clang ran into the following:

```
OnlineTools.cpp:277:29: warning: adding 'bool' to a string does not append to the string [-Wstring-plus-int]
    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
OnlineTools.cpp:277:29: note: use array indexing to silence this warning
    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
                            ^
           &                [                       ]
OnlineTools.cpp:277:54: warning: operator '?:' has lower precedence than '+'; '+' will be evaluated first [-Wparentheses]
    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
OnlineTools.cpp:277:54: note: place parentheses around the '+' expression to silence this warning
    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
OnlineTools.cpp:277:54: note: place parentheses around the '?:' expression to evaluate it first
    url += _T("&circular=") + child->vec->isLinear() ? _T("0") : _T("1") ;
                              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```

and after adding ()s in interim version

```
OnlineTools.cpp:277:29: error: invalid operands to binary expression ('const wchar_t[11]' and 'const wchar_t[2]')
    url += _T("&circular=") + (child->vec->isLinear() ? _T("0") : _T("1")) ;
           ~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
so the single line was split in two.
