### PR TITLE
Addressed clang warnings on "for loop has empty body"

### DIFF
--- a/SequenceTypeDNA.cpp
+++ b/SequenceTypeDNA.cpp
@@ -308,8 +308,7 @@ void SeqDNA::show_direct ( wxDC& dc )
     myass ( ch , "SeqDNA::show_direct2a" ) ;
     myass ( csgc , "SeqDNA::show_direct2b" ) ;
     b = ( ya - ch - oy ) / ( ch * csgc ) * itemsperline ;
-    for ( a = 0 ; a < b && a < s.length() ; a += itemsperline ) ;
-        
+ 
     myass ( itemsperline , "SeqDNA::show_direct3" ) ;
     myass ( cbs , "SeqDNA::show_direct4" ) ;
     for ( a = 0 ; a < s.length() ; a++ )

--- a/SequenceTypeRestriction.cpp
+++ b/SequenceTypeRestriction.cpp
@@ -81,7 +81,8 @@ void SeqRestriction::show ( wxDC& dc )
     yb += ya ;
     int n , csgc = can->NumberOfLines() , cbs = can->blocksize , bo = can->border ;
 	mylog ( "SeqRestriction::show" , "2" ) ;
-    for ( n = 0 ; n < csgc && can->seq[n] != this ; n++ ) ;
+    for ( n = 0 ; n < csgc && can->seq[n] != this ; n++ ) // n is used below
+	;
 	mylog ( "SeqRestriction::show" , "3" ) ;
     int cw = can->charwidth , ch = can->charheight ;
     int ox = bo + cw + cw * endnumberlength ;


### PR DESCRIPTION
 ```
SequenceTypeDNA.cpp:311:65: warning: for loop has empty body [-Wempty-body]
    for ( a = 0 ; a < b && a < s.length() ; a += itemsperline ) ;
                                                                ^
SequenceTypeDNA.cpp:311:65: note: put the semicolon on a separate line to silence this warning
```
Addressed first commit. a is reassigned another value without being read - this loop has no effect and was removed.
```
SequenceTypeRestriction.cpp:84:59: warning: for loop has empty body [-Wempty-body]
    for ( n = 0 ; n < csgc && can->seq[n] != this ; n++ ) ;
                                                          ^
SequenceTypeRestriction.cpp:84:59: note: put the semicolon on a separate line to silence this warning
```
Addressed in second commit. Semicolon was placed in line below.