### PR TITLE
Revisiting clang warnings

### DIFF
--- a/SCFtype.cpp
+++ b/SCFtype.cpp
@@ -104,7 +104,7 @@ SCFtype::SCFtype ()
 	{
 	}
 
-bool SCFtype::parse ( wxString filename )
+bool SCFtype::parse ( const wxString& filename )
 	{
 	wxFile f ( filename , wxFile::read ) ;
 	long l = f.Length() ;
@@ -114,12 +114,11 @@ bool SCFtype::parse ( wxString filename )
 	
 	if ( *(t+0) != '.' || *(t+1) != 's' || *(t+2) != 'c' || *(t+3) != 'f' )
 		{
-		delete t ;
+		delete [] t ;
 		return false ; // No luck
 		}
 	
 	SCF_Header *header = (SCF_Header*) t ;
-
 
 	wxString version ;
 	version += (*header).version[0] ;
@@ -129,6 +128,7 @@ bool SCFtype::parse ( wxString filename )
 	if ( (*header).version[0] < '3' )
 		{
 		wxMessageBox ( _T("Cannot read SFC prior to 3.0, this is ") + version ) ;
+                delete [] t;
 		return false ;
 		}
 

--- a/SCFtype.h
+++ b/SCFtype.h
@@ -10,7 +10,7 @@ class SCFtype
 	{
 	public :
 	SCFtype () ;
-	bool parse ( wxString filename ) ;
+	bool parse ( const wxString& filename ) ;
 	
 	TSequencerData sd ;
 	

--- a/TVirtualGel.cpp
+++ b/TVirtualGel.cpp
@@ -249,7 +249,7 @@ void TMyGelControl::OnDraw(wxDC& dc)
 
     int tw , th ;
     wxString title = _T("t_gelname_") + vg->type ;
-    title = wxString::Format ( txt(title.c_str()) , vg->percent ) ;
+    title = wxString::Format ( txt(title) , vg->percent ) ;
     dc.SetTextForeground ( *wxBLACK ) ;
     dc.SetFont ( *bigFont ) ;
     dc.GetTextExtent ( title , &tw , &th ) ;
@@ -415,7 +415,7 @@ void TMyGelControl::OnSaveAsBitmap(wxCommandEvent &event)
     dc.Clear() ;
 	OnDraw ( dc ) ;
     wxString title = _T("t_gelname_") + vg->type ;
-    title = wxString::Format ( txt(title.c_str()) , vg->percent ) ;
+    title = wxString::Format ( txt(title) , vg->percent ) ;
     myapp()->frame->saveImage ( &bmp , title ) ;
     }
     

--- a/main.cpp
+++ b/main.cpp
@@ -106,12 +106,12 @@ wxString implode ( wxString sep , wxArrayString &r )
 	return ret ;
 	}
 
-wxString txt ( char *item )
+const wxString txt ( const char * const item )
 	{
 	return txt ( wxString(item,wxConvUTF8) ) ;
 	}
 
-wxString txt ( wxString item )
+const wxString txt ( wxString item )
     {
 #ifndef __WXMSW__
 	 if ( item.MakeUpper().Left(2) == _T("M_") )
@@ -129,7 +129,7 @@ wxString txt ( wxString item )
 // END GLOBAL FUNCTIONS
 
 
-void MyApp::registerFileExtension ( wxString extension )
+void MyApp::registerFileExtension ( const wxString& extension )
     {
 #ifdef __WXMSW__    
     wxRegKey regKey;
@@ -155,7 +155,7 @@ void MyApp::registerFileExtension ( wxString extension )
 #endif
     }
     
-void MyApp::registerProtocol ( wxString extension )
+void MyApp::registerProtocol ( const wxString& extension )
     {
 #ifdef __WXMSW__    
     wxRegKey regKey;

--- a/main.h
+++ b/main.h
@@ -202,8 +202,8 @@ class MyApp : public wxApp
 		wxStopWatch sw ;
     
     private :
-    virtual void registerFileExtension ( wxString extension ) ; ///< Registers a file extension to GENtle (windows only).
-    virtual void registerProtocol ( wxString extension ) ; ///< Registers a protocol to GENtle (windows only).
+    virtual void registerFileExtension ( const wxString& extension ) ; ///< Registers a file extension to GENtle (windows only).
+    virtual void registerProtocol ( const wxString& extension ) ; ///< Registers a protocol to GENtle (windows only).
     wxFile *errout ; ///< The ERROR.txt file handler for do_my_ass
     wxFile *logout ; ///< The LOG.txt file handler for do_my_log
     int total_log_time ; ///< The log timer for do_my_log
@@ -331,16 +331,16 @@ void explode ( wxString sep , wxString s , wxArrayString &r ) ;
 wxString implode ( wxString sep , wxArrayString &r ) ;
 /*
 //  \brief Returns the current language version of the "item" /
-char* txt ( wxString item ) ;
+const char * txt ( const wxString item ) ;
 
 //  \brief Returns the current language version of the "item" /
-char* txt ( char *item ) ;
+const char* txt ( const char * const item ) ;
 */
 /** \brief Returns the current language version of the "item" */
-wxString txt ( wxString item ) ;
+const wxString txt ( const wxString item ) ;
 
 /** \brief Returns the current language version of the "item" */
-wxString txt ( char *item ) ;
+const wxString txt ( const char * const item ) ;
 
 /** \brief Returns a pointer to the application */
 MyApp *myapp () ;


### PR DESCRIPTION
txt() now returns a const wxString, which eliminates the warnings.
clang found extra missing []s at delete for an early return from a function.