### PR TITLE
Introduced const wxstring refs

### DIFF
--- a/ABItype.cpp
+++ b/ABItype.cpp
@@ -22,9 +22,9 @@ ABItype::~ABItype ()
 	\param t Pointer to the data to parse
 	\param l Length of the data
 */
-int ABItype::getCMBF ( unsigned char *t , int l )
+int ABItype::getCMBF ( const unsigned char * const t, const int l ) const
     {
-    unsigned char *s , *r = NULL ;
+    const unsigned char *s , *r = NULL ;
     for ( s = t + l - 8 ; s > t ; s-- )
        {
        if ( *s == 'C' )
@@ -39,7 +39,8 @@ int ABItype::getCMBF ( unsigned char *t , int l )
           }
        }
     if ( !r ) return -1 ;
-    return r - t ;
+    // difference between two pointers that should be positive
+    return (int) (r - t) ;
     }
     
 /** \brief Parses an ABI format file
@@ -50,7 +51,7 @@ int ABItype::getCMBF ( unsigned char *t , int l )
 	* - finding the offset for the first CMBF structure
 	* - iterating through the CMBF structures
 */
-void ABItype::parse ( wxString filename )
+void ABItype::parse ( const wxString& filename ) 
     {
 	wxFile f ( filename , wxFile::read ) ;
 	long l = f.Length() ;
@@ -101,7 +102,7 @@ void ABItype::parse ( wxString filename )
  	* - 128 for a valid Mac file
  	* - -1 if the file is invalid
 */
-int ABItype::getMacOffset ( unsigned char *t )
+int ABItype::getMacOffset ( const unsigned char * const t ) const
     {
     int r = 0 ;
     if ( t[r+0]=='A' && t[r+1]=='B' && t[r+2]=='I' && t[r+3]=='F' ) return r ;
@@ -114,7 +115,7 @@ int ABItype::getMacOffset ( unsigned char *t )
 	\param t Pointer to the raw data
 	\param from Offset; is changed after the structure is read
 */    
-TFLAG ABItype::getFlag ( unsigned char *t , int &from )
+TFLAG ABItype::getFlag ( const unsigned char * const t , int &from ) const
     {
     TFLAG r ;
     r.data = NULL ;
@@ -131,7 +132,7 @@ TFLAG ABItype::getFlag ( unsigned char *t , int &from )
     return r ;
     }
     
-wxString ABItype::getText ( unsigned char *t , int &from )
+wxString ABItype::getText ( const unsigned char * const t , int &from ) const
     {
     wxString r ;
     int l = t[from++] ;
@@ -140,18 +141,18 @@ wxString ABItype::getText ( unsigned char *t , int &from )
     }
 
 // This function does not appear to be used anywhere...
-int ABItype::getInt10 ( unsigned char *t , int &from )
+int ABItype::getInt10 ( const unsigned char * const t , int &from ) const
     {
     from += 10 ; // Essentially ignoring
 	return 0 ;
     }
     
-int ABItype::getInt1 ( unsigned char *t , int &from )
+int ABItype::getInt1 ( const unsigned char * const t , int &from ) const
     {
     return (unsigned char) t[from++] ;
     }
     
-int ABItype::getInt2 ( unsigned char *t , int &from )
+int ABItype::getInt2 ( const unsigned char * const t , int &from ) const
     {
     int r = 0 ;
     int t1 = (unsigned char) t[from++] ;
@@ -160,7 +161,7 @@ int ABItype::getInt2 ( unsigned char *t , int &from )
     return r ;
     }
     
-int ABItype::getInt4 ( unsigned char *t , int &from )
+int ABItype::getInt4 ( const unsigned char * const t , int &from ) const
     {
     int r = 0 ;
     int t1 = getInt2 ( t , from ) ;
@@ -169,7 +170,7 @@ int ABItype::getInt4 ( unsigned char *t , int &from )
     return r ;
     }
     
-wxString ABItype::getStr ( unsigned char *t , int from , int len )
+wxString ABItype::getStr ( const unsigned char * const t , const int from , const int len ) const
     {
     wxString r ;
     for ( int a = 0 ; a < len ; a++ ) r += t[from+a] ;
@@ -183,7 +184,7 @@ wxString ABItype::getStr ( unsigned char *t , int from , int len )
 	\param id The flag (type) of the record
 	\param num The number of the record
 */    
-int ABItype::getRecord ( wxString id , int num )
+int ABItype::getRecord ( const wxString& id , const int num ) const
     {
     unsigned int a ;
     for ( a = 0 ; a < vf.size() && ( vf[a].flag != id || vf[a].instance != num ) ; a++ ) ;
@@ -194,7 +195,7 @@ int ABItype::getRecord ( wxString id , int num )
 /** \brief Finds a specific sequence record
 	\param num The number of the sequence record
 */    
-wxString ABItype::getSequence ( int num )
+wxString ABItype::getSequence ( const int num ) const
     {
     wxString r ;
     int a = getRecord ( _T("PBAS") , num ) , b ;
@@ -207,7 +208,7 @@ wxString ABItype::getSequence ( int num )
 	\param id The flag (type) of the record
 	\param num The number of the record
 */    
-wxString ABItype::getRecordPascalString ( wxString id , int num )
+wxString ABItype::getRecordPascalString ( const wxString& id , const int num ) const
     {
     int i = getRecord ( id , num ) ;
     if ( i == -1 ) return _T("") ;
@@ -218,7 +219,7 @@ wxString ABItype::getRecordPascalString ( wxString id , int num )
 	\param id The flag (type) of the record
 	\param num The number of the record
 */    
-int ABItype::getRecordValue ( wxString id , int num )
+int ABItype::getRecordValue ( const wxString& id , const int num ) const
     {
     int i = getRecord ( id , num ) ;
     if ( i == -1 ) return 0 ;
@@ -239,7 +240,7 @@ TFLAG::~TFLAG ()
     }    
 
 /// \brief Reads a Pascal-like string from the data   
-wxString TFLAG::getPascalString ()
+wxString TFLAG::getPascalString () const
     {
     if ( !data )
        {

--- a/ABItype.h
+++ b/ABItype.h
@@ -26,7 +26,7 @@ class TFLAG
     int pos , after ;
     unsigned char *data ;
     
-    wxString getPascalString () ;
+    wxString getPascalString () const ;
     
     wxString flag ; ///< The flag name
     int instance ; ///< Flag data item
@@ -48,22 +48,22 @@ class ABItype
     ABItype () ;
     ~ABItype () ;
     
-    int getRecord ( wxString id , int num ) ;
-    int getRecordValue ( wxString id , int num ) ;
-    wxString getRecordPascalString ( wxString id , int num ) ;
-    wxString getSequence ( int num = 2 ) ;
-    int getMacOffset ( unsigned char *t ) ;
+    int getRecord ( const wxString& id , const int num ) const ;
+    int getRecordValue ( const wxString& id , const int num ) const ;
+    wxString getRecordPascalString ( const wxString& id , const int num ) const ;
+    wxString getSequence ( const int num = 2 ) const ;
+    int getMacOffset ( const unsigned char * const t ) const ;
     
     // Parser functions
-    void parse ( wxString filename ) ;
-    TFLAG getFlag ( unsigned char *t , int &from ) ;
-    wxString getStr ( unsigned char *t , int from , int len ) ;
-    wxString getText ( unsigned char *t , int &from ) ; ///< Reads a Pascal-like string
-    int getInt1 ( unsigned char *t , int &from ) ; ///< Reads a 1-byte number
-    int getInt2 ( unsigned char *t , int &from ) ; ///< Reads a 2-byte number
-    int getInt4 ( unsigned char *t , int &from ) ; ///< Reads a 4-byte number
-    int getInt10 ( unsigned char *t , int &from ) ; ///< Jumps ahead 10 bytes, ignores contents
-    int getCMBF ( unsigned char *t , int l ) ; ///< Reads a Pascal-like string with known length
+    void parse ( const wxString& filename ) ;
+    TFLAG getFlag ( const unsigned char * const t , int &from ) const ;
+    wxString getStr ( const unsigned char * const t , const  int from , const int len ) const ;
+    wxString getText ( const unsigned char * const t , int &from ) const ; ///< Reads a Pascal-like string
+    int getInt1 ( const unsigned char * const t , int &from ) const ; ///< Reads a 1-byte number
+    int getInt2 ( const unsigned char * const t , int &from ) const ; ///< Reads a 2-byte number
+    int getInt4 ( const unsigned char * const t , int &from ) const ; ///< Reads a 4-byte number
+    int getInt10 ( const unsigned char * const t , int &from ) const ; ///< Jumps ahead 10 bytes, ignores contents
+    int getCMBF ( const unsigned char * const t , const int l ) const ; ///< Reads a Pascal-like string with known length
     
     // Variables
     vector <TFLAG> vf ; ///< All the flags

--- a/ABIviewer.cpp
+++ b/ABIviewer.cpp
@@ -312,7 +312,7 @@ void TABIviewer::initme ()
     sc->SetFocus() ;
     }
     
-wxString TABIviewer::getName ()
+const wxString TABIviewer::getName () const
     {
     return vec->getName() ;
     }

--- a/ABIviewer.h
+++ b/ABIviewer.h
@@ -19,7 +19,7 @@ class TABIviewer : public ChildBase
     virtual ~TABIviewer () ; ///< Destructor
     
     virtual void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
     virtual void showSequence () ; ///< Show/refresh the sequence
     virtual wxString getStat () ; ///< Get statistics as a wxString
     virtual void showStat () ; ///< Show the statistics

--- a/Alignment.cpp
+++ b/Alignment.cpp
@@ -6,17 +6,6 @@
 #include <wx/textfile.h>
 #include <wx/filename.h>
 
-#ifdef __DEBIAN__
-#ifndef USE_EXTERNAL_CLUSTALW
-	#define USE_EXTERNAL_CLUSTALW
-#endif
-#endif
-
-#ifndef USE_EXTERNAL_CLUSTALW
- #include "clustalw/clustalw.h"
- int clustalw_main(int argc,char **argv) ;
-#endif
-
 BEGIN_EVENT_TABLE(TAlignment, MyChildBase)
     EVT_CLOSE(ChildBase::OnClose)
     EVT_SET_FOCUS(ChildBase::OnFocus)
@@ -325,9 +314,8 @@ void* TAlignment::Entry()
     }
     out.Close() ;
 
-#ifdef USE_EXTERNAL_CLUSTALW // Use external ClustalW
+    // Using external ClustalW
     wxString bn ;
-    
 #ifdef __WXMSW__
 	// This is not used anymore under Windows
     bn = tmpdir + _T("\\clustalw.bat") ;
@@ -346,22 +334,6 @@ void* TAlignment::Entry()
 //	cout << "Executing " << bn.mb_str() << endl ;
 #endif 
     wxExecute ( bn , wxEXEC_SYNC ) ;
-	
-	
-#else // Using internal ClustalW - cool!
-
-
-    wxString a1 = wxString::Format ( _T("/gapopen=%d") , gap_penalty ) ;
-    wxString a2 = wxString::Format ( _T("/gapext=%d") , mismatch ) ;
-    wxString text = tmpdir + _T("/clustalw.txt") ;
-    char *av[4] ;
-    av[0] = new char[100] ; strcpy ( av[0] , "clustalw.exe" ) ;
-    av[1] = new char[500] ; strcpy ( av[1] , text.mb_str() ) ;
-    av[2] = new char[100] ; strcpy ( av[2] , a1.mb_str() ) ;
-    av[3] = new char[100] ; strcpy ( av[3] , a2.mb_str() ) ;
-    clustalw_main ( 4 , av ) ;
-#endif
-
     
     wxString aln = tmpdir + _T("/clustalw.aln") ;
     wxTextFile in ( aln ) ;
@@ -721,7 +693,7 @@ void TAlignment::updateSequence ()
     sc->SilentRefresh() ;
     }
     
-wxString TAlignment::getName ()
+const wxString TAlignment::getName () const
     {
     return name.IsEmpty() ? _T("Alignment") : name ;
     }
@@ -1142,7 +1114,7 @@ void TAlignment::OnFileSave ( wxCommandEvent &ev )
         if ( lines[a].isIdentity ) continue ;
 
         wxString p = lines[a].v->getParams() ;
-        lines[a].v->setParams ( _T("") ) ;
+        lines[a].v->setParams ( txt("") ) ;
         d += lines[a].v->getName() + _T("\n") ;
         d += lines[a].v->getDatabase() + _T("\n") ;
         d += lines[a].s + _T("\n") ;

--- a/Alignment.h
+++ b/Alignment.h
@@ -54,7 +54,7 @@ class TAlignment : public ChildBase,wxThreadHelper
     virtual ~TAlignment () ; ///< Destructor
     
     virtual void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns "Alignment"
+    virtual const wxString getName () const ; ///< Returns "Alignment"
 
     virtual void* Entry() ; // wxThreadHelper
 

--- a/AlignmentAppearanceDialog.cpp
+++ b/AlignmentAppearanceDialog.cpp
@@ -23,7 +23,7 @@ void AlignmentAppearanceDialog::OnCharHook(wxKeyEvent& event)
     else event.Skip() ;
     }
 
-void AlignmentAppearanceDialog::addLine ( wxString name , wxArrayString &as , wxFlexGridSizer *sizer )
+void AlignmentAppearanceDialog::addLine ( const wxString& name , wxArrayString &as , wxFlexGridSizer *sizer )
     {
     wxBoxSizer *line = new wxBoxSizer ( wxHORIZONTAL ) ;
     wxButton *col = new wxButton ( this , ALIGN_APPEARANCE_LINE_COLOR_BUTTON1 + line_color_buttons , 

--- a/AlignmentAppearanceDialog.h
+++ b/AlignmentAppearanceDialog.h
@@ -25,7 +25,7 @@ class AlignmentAppearanceDialog : public wxDialog
     
     private :
     void set_pen ( SequenceCharMarkup &scm , int id , int border ) ; ///< Sets a pen in the markup object; used by OnOK
-    void addLine ( wxString name , wxArrayString &as , wxFlexGridSizer *sizer ) ; ///< Adds a line of elements (radio boxes, buttons)
+    void addLine ( const wxString& name , wxArrayString &as , wxFlexGridSizer *sizer ) ; ///< Adds a line of elements (radio boxes, buttons)
     
     vector <wxRadioBox*> radioboxes ;
     vector <wxSpinCtrl*> thickness ;

--- a/AminoAcids.cpp
+++ b/AminoAcids.cpp
@@ -261,7 +261,7 @@ void TAminoAcids::initme ()
     mylog ( "TAminoAcids::initme" , "11b" ) ;
     }
     
-wxString TAminoAcids::getName ()
+const wxString TAminoAcids::getName () const
     {
     return vec->getName() ;
     }
@@ -452,7 +452,7 @@ void TAminoAcids::OnEditMode(wxCommandEvent& event)
         }    
     }
 
-void TAminoAcids::invokeVectorEditor ( wxString what , int num , bool forceUpdate )
+void TAminoAcids::invokeVectorEditor ( const wxString& what , const int num , const bool forceUpdate )
 	{
 	vec->undo.start ( txt("u_vec_edit") ) ;
 	TVectorEditor ve ( this , txt("t_vector_editor") , vec ) ;
@@ -645,7 +645,7 @@ void TAminoAcids::OnListBox ( wxCommandEvent& event )
     handleListBox ( lb->GetStringSelection() ) ;
     }
 
-void TAminoAcids::handleListBox ( wxString t )
+void TAminoAcids::handleListBox ( const wxString& t )
 	{
 	mylog ( "TAminoAcids::handleListBox" , "1" ) ;
 	bool update = false ;

--- a/AminoAcids.h
+++ b/AminoAcids.h
@@ -21,7 +21,7 @@ class TAminoAcids : public ChildBase
     virtual ~TAminoAcids () ; ///< Destructor
     
     virtual void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the name of the TVector structure
+    virtual const wxString getName () const ; ///< Returns the name of the TVector structure
     virtual void showSequence () ; ///< Update the sequence display
     virtual void showStat () ; ///< Show the sequence statistics box
     
@@ -37,7 +37,7 @@ class TAminoAcids : public ChildBase
     virtual void OnAsNewFeature(wxCommandEvent& event); ///< "Selection as new feature" event handler
     virtual void OnBlastAA(wxCommandEvent& event); ///< "Blast sequence" event handler
     virtual void OnPhotometer(wxCommandEvent& event); ///< "Start photometer calculator" event handler
-    virtual void invokeVectorEditor ( wxString what = _T("") , int num = 0 , bool forceUpdate = false ) ; ///< "Edit sequence dialog" event handler
+    virtual void invokeVectorEditor ( const wxString& what = _T("") , const int num = 0 , const bool forceUpdate = false ) ; ///< "Edit sequence dialog" event handler
     virtual void OnHorizontal ( wxCommandEvent& event ) ; ///< "Toggle horizontal/vertical" event handler
     virtual void OnListBox ( wxCommandEvent& event ) ; ///< "List box choice" event handler
     virtual void OnIP ( wxCommandEvent& event ) ; ///< "Inline plot dropdown box" event handler
@@ -51,7 +51,7 @@ class TAminoAcids : public ChildBase
     virtual void Undo(wxCommandEvent& event); ///< "Undo" event handler
     virtual void Redo(wxCommandEvent& event); ///< "Redo" event handler (unused)
     virtual void updateUndoMenu () ; ///< Updates the message for the undo function
-    virtual void handleListBox ( wxString t ) ; ///< Choses a new entry from the listbox
+    virtual void handleListBox ( const wxString& t ) ; ///< Choses a new entry from the listbox
     virtual bool HasUndoData () ;
         
     // Variables

--- a/ChildBase.cpp
+++ b/ChildBase.cpp
@@ -43,16 +43,17 @@ void ChildBase::Maximize ( bool isit )
   Activate () ;
 }
 
-void ChildBase::showName ( wxString x )
-    {
-    if ( x.IsEmpty() )
-       {
-       x = getName() ;
-       if ( vec && vec->isChanged() ) x += _T("*") ;
-       }
-    if ( myapp()->frame->GetTitle() != x )
-        myapp()->frame->SetTitle ( x ) ;
+void ChildBase::showName ( const wxString& x )
+{
+    wxString s=x;
+    if ( x.IsEmpty() ) {
+       s = getName() ;
+       if ( vec && vec->isChanged() ) s += _T("*") ;
     }
+    if ( myapp()->frame->GetTitle() != s ) {
+        myapp()->frame->SetTitle ( s ) ;
+    }
+}
     
 void ChildBase::OnFocus(wxFocusEvent& event)
     {

--- a/ChildBase.h
+++ b/ChildBase.h
@@ -33,8 +33,8 @@ class ChildBase : public MyChildBase
     ChildBase(wxWindow *parent, const wxString& title, const wxPoint& pos, const wxSize& size, const long style) ; ///< Constructor
     ChildBase(wxWindow *parent, const wxString& title); ///< Constructor
 
-    virtual wxString getName () { return _T("") ; } ///< Returns the name of the module (e.g., the vector name)
-    virtual void showName ( wxString x = _T("") ) ; ///< Shows the module name in the window title
+    virtual const wxString getName () const { return _T("") ; } ///< Returns the name of the module (e.g., the vector name)
+    virtual void showName ( const wxString& x = "" ) ; ///< Shows the module name in the window title
     virtual void OnFocus(wxFocusEvent& event); ///< Event handler for focus event
     virtual bool caniclose(wxCloseEvent& event); ///< Checks for unsaved edits
     virtual void OnFileSave(wxCommandEvent& WXUNUSED(event) ) {} ; ///< Event handler for save command

--- a/CloningAssistant.cpp
+++ b/CloningAssistant.cpp
@@ -113,7 +113,7 @@ void TCloningAssistant::initme ()
 //	Refresh () ;
 	}
 
-wxString TCloningAssistant::getName ()
+const wxString TCloningAssistant::getName () const
 	{
 	return txt("t_cloning_assistant") ;
 	}
@@ -139,7 +139,7 @@ void TCloningAssistant::EnforceRefesh ()
 	panel->Refresh () ;
 	}
 
-TDDR *TCloningAssistant::new_from_vector ( TVector *v , int drag )
+TDDR *TCloningAssistant::new_from_vector ( TVector * const v , const int drag )
 	{
 	TDDR *n = new TDDR ( DDR_AS_SEQUENCE ) ;
 	n->title = v->getName() ;

--- a/CloningAssistant.h
+++ b/CloningAssistant.h
@@ -97,7 +97,7 @@ class TCloningAssistant : public ChildBase
     public :
 	TCloningAssistant(wxWindow *parent, const wxString& title) ; ///< Constructor
     virtual ~TCloningAssistant () ; ///< Destructor
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
     virtual void EnforceRefesh () ; ///< Refreshes the module display
 
     virtual void initme () ;
@@ -108,7 +108,7 @@ class TCloningAssistant : public ChildBase
     private :
 	friend class TCloningAssistantPanel ;
 	
-	TDDR *new_from_vector ( TVector *v , int drag = DDR_NONE ) ;
+	TDDR *new_from_vector ( TVector * const v , const int drag = DDR_NONE ) ;
 	
 	vector <TVector*> vectors ;
 	TDDR *base , *vlist , *tlist ;

--- a/ExternalInterface.cpp
+++ b/ExternalInterface.cpp
@@ -101,12 +101,12 @@ void ExternalInterface::initme ()
     if ( panel->t1 ) panel->t1->SetFocus () ;
     }
 
-wxString ExternalInterface::getName ()
+const wxString ExternalInterface::getName () const
     {
     return _T("External Interface") ;
     }
 
-void ExternalInterface::runBlast ( wxString seq , wxString prg ) 
+void ExternalInterface::runBlast ( const wxString& seq , wxString prg ) 
 {
     EIpanel *bl = new EIpanel ( nb , EI_BLAST ) ;    
     prg.MakeUpper() ;

--- a/ExternalInterface.h
+++ b/ExternalInterface.h
@@ -104,19 +104,19 @@ class EIpanel : public wxPanel
 /**	\brief The External Interface ChildBase class
 */
 class ExternalInterface : public ChildBase
-    {
-    public :
+{
+  public :
     ExternalInterface(wxWindow *parent, const wxString& title) ; ///< Constructor
     ~ExternalInterface () ; ///< Destructor
     
     void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the class name
+    virtual const wxString getName () const ; ///< Returns the class name
 
-    virtual void runBlast ( wxString seq , wxString prg ) ; ///< Directly runs a BLAST query
+    virtual void runBlast ( const wxString& seq , wxString prg ) ; ///< Directly runs a BLAST query
 
     wxNotebook *nb ; ///< Pointer to the wxNotebook class containing one or more EIpanel
 
     DECLARE_EVENT_TABLE()
-    } ;
+} ;
 
 #endif

--- a/MyChild.cpp
+++ b/MyChild.cpp
@@ -546,7 +546,7 @@ void MyChild::OnLigation(wxCommandEvent& event)
     myapp()->frame->lastCocktail.Clear () ;
     }
 */
-wxString MyChild::getName ()
+const wxString MyChild::getName () const
     {
     return vec->getName() ;
     }

--- a/MyChild.h
+++ b/MyChild.h
@@ -97,7 +97,7 @@ public:
 
     virtual void initme () ; ///< Initializes the module
     virtual void initPanels () ; ///< Initializes the panels
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
     virtual void EnforceRefesh () ; ///< Force display refresh
     virtual void updateSequenceCanvas ( bool remember = false ) ; ///< Refresh the sequence display
     virtual wxString doExtractAA ( bool coding = true ) ; ///< Extract amino acid sequence from DNA

--- a/PrimerDesign.cpp
+++ b/PrimerDesign.cpp
@@ -201,7 +201,7 @@ void TPrimerDesign::OnImportPrimer ( wxCommandEvent &ev )
     guessOptNuc () ;
     }
 
-void TPrimerDesign::AddPrimer ( wxString s , wxString pname )
+void TPrimerDesign::AddPrimer ( const wxString& s , const wxString& pname )
     {
     TPrimer best ;
     int a , bestVal = 0 ;
@@ -538,7 +538,7 @@ void TPrimerDesign::OnPaste (wxCommandEvent& event)
     }
 
 
-wxString TPrimerDesign::getName ()
+const wxString TPrimerDesign::getName () const
     {
     return vec->getName() ;
     }

--- a/PrimerDesign.h
+++ b/PrimerDesign.h
@@ -26,8 +26,8 @@ class TPrimerDesign : public ChildBase
     ~TPrimerDesign () ; ///< Destructor
     
     void initme () ; ///< Initialize
-    virtual wxString getName () ; ///< Returns the name of the vector
-    virtual void AddPrimer ( wxString s , wxString pname = _T("") ) ; ///< Add a primer to the module
+    virtual const wxString getName () const ; ///< Returns the name of the vector
+    virtual void AddPrimer ( const wxString& s , const wxString& pname = _T("") ) ; ///< Add a primer to the module
     virtual void showSequence () ; ///< Refresh the sequence map
     virtual void updateResultSequence () ; ///< Generates the resulting DNA and amino acid sequences from the template sequence and the primers
     virtual void updatePrimersFromSequence () ; ///< Updates the primers from the primer sequences in the map (after editing)

--- a/ProgramOptionsDialog.cpp
+++ b/ProgramOptionsDialog.cpp
@@ -520,12 +520,12 @@ void TEnzymeRules::lookup_options ( TEnzymeSettingsTab *est )
 	if ( est->met_dcm->GetValue() ) methylation += DCM_METHYLATION ;
 	}
 	
-bool TEnzymeRules::isEqual ( TEnzymeRules &r )
+bool TEnzymeRules::isEqual ( const TEnzymeRules &r ) const
 	{
  	return to_string() == r.to_string() ;
 	}    
      
-wxString TEnzymeRules::to_string ()
+wxString TEnzymeRules::to_string () const
 	{
 	wxString ret ;
 	ret += wxString::Format ( _T("useit=%d\r") , useit ) ;
@@ -551,7 +551,7 @@ wxString TEnzymeRules::to_string ()
 	return ret ;
 	}    
 
-void TEnzymeRules::from_string ( wxString &s )
+void TEnzymeRules::from_string ( const wxString &s )
 	{
 	init () ;
 	wxArrayString as ;

--- a/ProgramOptionsDialog.h
+++ b/ProgramOptionsDialog.h
@@ -97,10 +97,10 @@ class TEnzymeRules
 	virtual void save_global_settings () ; ///< Save global settings to the database
 	virtual void setup_options ( TEnzymeSettingsTab *est ) ; ///< Set options in the tab
 	virtual void lookup_options ( TEnzymeSettingsTab *est ) ; ///< Look up options from the tab
-	virtual bool isEqual ( TEnzymeRules &r ) ; ///< Compare with another set of settings
+	virtual bool isEqual ( const TEnzymeRules &r ) const ; ///< Compare with another set of settings
 	
-	virtual wxString to_string () ; ///< "Compress" to storable string
-	virtual void from_string ( wxString &s ) ; ///< "Decompress" from storage string
+	virtual wxString to_string () const ; ///< "Compress" to storable string
+	virtual void from_string ( const wxString &s ) ; ///< "Decompress" from storage string
 
 	virtual void getVectorCuts ( TVector *v ) ;
 	virtual wxColour *getColor ( int cuts ) ; ///< Returns a pointer to a wxColour structure with the correct color for the given number of cuts

--- a/RestrictionEnzymes.cpp
+++ b/RestrictionEnzymes.cpp
@@ -33,7 +33,7 @@ bool operator == ( const TFragment &f1 , const TFragment &f2 )
 	If any of name, sequence, note, location, cut, or overlap do
 	not match, FALSE is returned
 */
-bool TRestrictionEnzyme::differ ( TRestrictionEnzyme &e )
+bool TRestrictionEnzyme::differ ( const TRestrictionEnzyme &e ) const
     {
     if ( name != e.name ) return true ;
     if ( note != e.note ) return true ;
@@ -44,7 +44,7 @@ bool TRestrictionEnzyme::differ ( TRestrictionEnzyme &e )
     return false ;
     }
     
-wxString TRestrictionEnzyme::getEndUpperLeft ( bool first_strand )
+wxString TRestrictionEnzyme::getEndUpperLeft ( const bool first_strand ) const
     {
     wxString r ;
     for ( int a = 0 ; a < getCut(first_strand) ; a++ )
@@ -52,15 +52,16 @@ wxString TRestrictionEnzyme::getEndUpperLeft ( bool first_strand )
     return r ;
     }
     
-wxString TRestrictionEnzyme::getEndLowerLeft ( bool first_strand )
+wxString TRestrictionEnzyme::getEndLowerLeft ( const bool first_strand ) const
     {
-    wxString r , s = invertSequence () ;
+    wxString r ;
+    const wxString s = invertSequence () ;
     for ( int a = 0 ; a < getCut(first_strand)+getOverlap(first_strand) ; a++ )
         r += s.GetChar(a) ;
     return r ;
     }
     
-wxString TRestrictionEnzyme::getEndUpperRight ( bool first_strand )
+wxString TRestrictionEnzyme::getEndUpperRight ( const bool first_strand ) const
     {
     wxString r ;
     for ( int a = getCut(first_strand) ; a < sequence.length() ; a++ )
@@ -68,37 +69,38 @@ wxString TRestrictionEnzyme::getEndUpperRight ( bool first_strand )
     return r ;
     }
     
-wxString TRestrictionEnzyme::getEndLowerRight ( bool first_strand )
+wxString TRestrictionEnzyme::getEndLowerRight ( const bool first_strand ) const
     {
-    wxString r , s = invertSequence () ;
+    wxString r;
+    const wxString s = invertSequence () ;
     for ( int a = getCut(first_strand)+getOverlap(first_strand) ; a < s.length() ; a++ )
         r += s.GetChar(a) ;
     return r ;
     }
     
-wxString TRestrictionEnzyme::invertSequence ()
+wxString TRestrictionEnzyme::invertSequence () const
     {
     TVector v ;
     v.setSequence ( sequence ) ;
     return v.transformSequence ( true , false ) . c_str() ;
     }
     
-int TRestrictionEnzyme::getCut ( bool first_strand )
+int TRestrictionEnzyme::getCut ( const bool first_strand ) const
 	{
 	return first_strand ? cut : sequence.length() - cut - overlap ;
 	}
 
-int TRestrictionEnzyme::getOverlap ( bool first_strand )
+int TRestrictionEnzyme::getOverlap ( const bool first_strand ) const
 	{
 	return overlap ;
 	}
 
-void TRestrictionEnzyme::setCut ( int c ) { cut = c ; }
-void TRestrictionEnzyme::setOverlap ( int o ) { overlap = o ; }
-wxString TRestrictionEnzyme::getName () { return name ; }
-void TRestrictionEnzyme::setName ( wxString _name ) { name = _name ; }
-wxString TRestrictionEnzyme::getSequence () { return sequence ; }
-bool TRestrictionEnzyme::isPalindromic () { return palindromic ; }
+void TRestrictionEnzyme::setCut ( const int c ) { cut = c ; }
+void TRestrictionEnzyme::setOverlap ( const int o ) { overlap = o ; }
+const wxString TRestrictionEnzyme::getName () const { return name ; }
+void TRestrictionEnzyme::setName ( const wxString& _name ) { name = _name ; }
+const wxString TRestrictionEnzyme::getSequence () const { return sequence ; }
+bool TRestrictionEnzyme::isPalindromic () const { return palindromic ; }
 
 void TRestrictionEnzyme::setSequence ( wxString _seq )
 	{
@@ -116,7 +118,7 @@ void TRestrictionEnzyme::setSequence ( wxString _seq )
 	\param w Screen width
 	\param h Screen height
 */
-void TRestrictionCut::linearUpdate ( int w , int h )
+void TRestrictionCut::linearUpdate ( const int w , const int h )
     {
     p.x = lp.x * w / STANDARDRADIUS + 2 ;
     p.y = lp.y * h / STANDARDRADIUS ;
@@ -126,18 +128,18 @@ void TRestrictionCut::linearUpdate ( int w , int h )
                         lastrect.GetHeight() ) ;
     }
     
-wxString TRestrictionCut::getNameAndPosition ()
+wxString TRestrictionCut::getNameAndPosition () const
     {
 	 if ( !myapp()->frame->showEnzymePos ) return getDisplayName() ;
     return wxString::Format ( _T("%s %d") , getDisplayName().c_str() , pos ) ;
     }
 
-bool TRestrictionCut::isHidden ( TVector *v )
+bool TRestrictionCut::isHidden ( const TVector * const v ) const
     {
     return v->isEnzymeHidden ( e->getName() ) ;
     }
 
-wxString TRestrictionCut::getDisplayName ()
+const wxString TRestrictionCut::getDisplayName () const
 	{
 	if ( display_name.IsEmpty() ) return e->getName() ;
 	return display_name ;
@@ -146,7 +148,7 @@ wxString TRestrictionCut::getDisplayName ()
 /** \brief Merges a cut with an isoenzyme for simplified display
 	\param c The restriction cut to merge
 */
-bool TRestrictionCut::join ( TRestrictionCut *c )
+bool TRestrictionCut::join ( TRestrictionCut * const c )
 	{
 	if ( pos != c->pos ) return false ;
 	if ( e->getSequence() != c->e->getSequence() ) return false ;
@@ -157,16 +159,16 @@ bool TRestrictionCut::join ( TRestrictionCut *c )
 	return true ;
 	}    
         
-wxString TRestrictionCut::getEndUpperLeft () { return e->getEndUpperLeft ( first_strand ) ; }
-wxString TRestrictionCut::getEndLowerLeft () { return e->getEndLowerLeft ( first_strand ) ; }
-wxString TRestrictionCut::getEndUpperRight () { return e->getEndUpperRight ( first_strand ) ; }
-wxString TRestrictionCut::getEndLowerRight () { return e->getEndLowerRight ( first_strand ) ; }
-int TRestrictionCut::getCut () { return e->getCut ( first_strand ) ; }
-int TRestrictionCut::getOverlap () { return e->getOverlap ( first_strand ) ; }
-void TRestrictionCut::setPos ( int p ) { pos = p ; }
-wxString TRestrictionCut::getSequence () { return e->getSequence () ; }
+const wxString TRestrictionCut::getEndUpperLeft () const { return e->getEndUpperLeft ( first_strand ) ; }
+const wxString TRestrictionCut::getEndLowerLeft () const { return e->getEndLowerLeft ( first_strand ) ; }
+const wxString TRestrictionCut::getEndUpperRight () const { return e->getEndUpperRight ( first_strand ) ; }
+const wxString TRestrictionCut::getEndLowerRight () const { return e->getEndLowerRight ( first_strand ) ; }
+int TRestrictionCut::getCut () const { return e->getCut ( first_strand ) ; }
+int TRestrictionCut::getOverlap () const { return e->getOverlap ( first_strand ) ; }
+void TRestrictionCut::setPos ( const int p ) { pos = p ; }
+const wxString TRestrictionCut::getSequence () const { return e->getSequence () ; }
 
-int TRestrictionCut::getPos ()
+int TRestrictionCut::getPos () const
 	{
 	if ( first_strand ) return pos ;
 	int a = pos ;
@@ -177,12 +179,12 @@ int TRestrictionCut::getPos ()
 	return a ;
 	}
 
-int TRestrictionCut::getFrom ()
+int TRestrictionCut::getFrom () const
 	{
 	return pos - e->getCut() ;
 	}
 
-int TRestrictionCut::getTo ()
+int TRestrictionCut::getTo () const
 	{
 	return pos - e->getCut() + e->getSequence().length() - 1 ;
 	}
@@ -190,7 +192,7 @@ int TRestrictionCut::getTo ()
 
 //------------------------------------------------------------------------------
 
-TProtease::TProtease ( wxString _name , wxString m , wxString _note )
+TProtease::TProtease ( const wxString& _name , const wxString& m , const wxString& _note )
     {
     name = _name ;
     str_match = m ;
@@ -214,7 +216,7 @@ TProtease::TProtease ( wxString _name , wxString m , wxString _note )
 
 
 
-bool TProtease::does_match ( wxString s )
+bool TProtease::does_match ( const wxString& s )
     {
     if ( s.length() != len() ) return false ;
     int a , b ;

--- a/RestrictionEnzymes.h
+++ b/RestrictionEnzymes.h
@@ -8,67 +8,67 @@
 
 /// \brief Stores a restriction enzyme
 class TRestrictionEnzyme
-    {
-    public :
+{
+  public :
 	TRestrictionEnzyme () { palindromic = false ; } ; ///< Empty constructor
 	~TRestrictionEnzyme () {} ; ///< Dummy destructor
 	
-    bool differ ( TRestrictionEnzyme &e ) ;
+    bool differ ( const TRestrictionEnzyme &e ) const;
     
-    wxString getEndUpperLeft ( bool first_strand = true ) ; ///< The "upper left" sequence after the cut
-    wxString getEndLowerLeft ( bool first_strand = true ) ; ///< The "lower left" sequence after the cut
-    wxString getEndUpperRight ( bool first_strand = true ) ; ///< The "upper right" sequence after the cut
-    wxString getEndLowerRight ( bool first_strand = true ) ; ///< The "lower right" sequence after the cut
+    wxString getEndUpperLeft ( const bool first_strand = true ) const ; ///< The "upper left" sequence after the cut
+    wxString getEndLowerLeft ( const bool first_strand = true ) const ; ///< The "lower left" sequence after the cut
+    wxString getEndUpperRight ( const bool first_strand = true ) const ; ///< The "upper right" sequence after the cut
+    wxString getEndLowerRight ( const bool first_strand = true ) const ; ///< The "lower right" sequence after the cut
     
-    wxString invertSequence () ; ///< The recognition sequence, inverted
+    wxString invertSequence () const ; ///< The recognition sequence, inverted
     
-    int getCut ( bool first_strand = true ) ;
-    void setCut ( int c ) ;
-    int getOverlap ( bool first_strand = true ) ;
+    int getCut ( bool first_strand = true ) const ;
+    void setCut ( const int c ) ;
+    int getOverlap ( const bool first_strand = true ) const ;
     void setOverlap ( int o ) ;
-    wxString getName () ;
-    void setName ( wxString _name ) ;
-    wxString getSequence () ;
+    const wxString getName () const ;
+    void setName ( const wxString& _name ) ;
+    const wxString getSequence () const ;
     void setSequence ( wxString _seq ) ;
-    bool isPalindromic () ;
+    bool isPalindromic () const ;
     
     /// The physical location of the vial containing the enzyme, if entered
     wxString location , note ; ///< A note about the enzyme, if entered
     unsigned long dbid ; ///< Database ID of the enzyme
 
-	private :
+  private :
     /// The enzyme name
     wxString name , sequence ; ///< The recognition sequence
     bool palindromic ;
     /// Where the cut occurs
     int cut , overlap ; ///< Length of the sticky ends (negative=<--)
-    } ;
+} ;
 
 /// \brief Stores a specific cut of a restriction enzyme
 class TRestrictionCut
-    {
-    public :
+{
+  public :
     TRestrictionCut ( int _pos , TRestrictionEnzyme *_e , bool _first_strand = true ) ///< Constructor
         { pos = _pos ; e = _e ; first_strand = _first_strand ; }
-	~TRestrictionCut () {} ; ///< Dummy destructor
+    ~TRestrictionCut () {} ; ///< Dummy destructor
         
     void linearUpdate ( int w , int h ) ;
-    wxString getNameAndPosition () ; ///< Returns the enzyme name and cut pusition
-    bool isHidden ( TVector *v ) ; ///< Is this enzyme in this TVector hidden?
-    wxString getDisplayName () ; ///< Returns the enzyme name (or the joined names)
+    wxString getNameAndPosition () const ; ///< Returns the enzyme name and cut pusition
+    bool isHidden ( const TVector * const v ) const ; ///< Is this enzyme in this TVector hidden?
+    const wxString getDisplayName () const ; ///< Returns the enzyme name (or the joined names)
     bool join ( TRestrictionCut *c ) ;
 
-    wxString getEndUpperLeft () ; ///< The "upper left" sequence after the cut
-    wxString getEndLowerLeft () ; ///< The "lower left" sequence after the cut
-    wxString getEndUpperRight () ; ///< The "upper right" sequence after the cut
-    wxString getEndLowerRight () ; ///< The "lower right" sequence after the cut
-	int getCut () ;
-	int getOverlap () ;
-	int getPos () ;
-	void setPos ( int p ) ;
-	int getFrom () ;
-	int getTo () ;
-	wxString getSequence () ;
+    const wxString getEndUpperLeft () const ; ///< The "upper left" sequence after the cut
+    const wxString getEndLowerLeft () const ; ///< The "lower left" sequence after the cut
+    const wxString getEndUpperRight () const ; ///< The "upper right" sequence after the cut
+    const wxString getEndLowerRight () const ; ///< The "lower right" sequence after the cut
+    int getCut () const ;
+    int getOverlap () const ;
+    int getPos () const ;
+    void setPos ( const int p ) ;
+    int getFrom () const ;
+    int getTo () const ;
+    const wxString getSequence () const ;
 	
     TRestrictionEnzyme *e ; ///< Cutting enzyme
     wxString display_name ; ///< The name to display
@@ -78,22 +78,22 @@ class TRestrictionCut
     wxRect lastrect ;
     wxPoint p , lp ;
     wxTreeItemId treeid ; ///< ID of the cut in the TVectorTree
-    
-    private:
+
+  private:
     int pos ; ///< Position of the cut
     bool first_strand ;
-    } ;
+} ;
 
 bool operator < ( const TRestrictionCut &c1 , const TRestrictionCut &c2 ) ;
 bool operator == ( const TRestrictionCut &c1 , const TRestrictionCut &c2 ) ;
 
 /// \brief Class to store a protease
 class TProtease
-    {
-    public :
-    TProtease ( wxString _name = _T("") , wxString m = _T("") , wxString _note = _T("") ) ; ///< Constructor
-    bool does_match ( wxString s ) ; ///< Does this protease recognize this sequence?
-    inline int len() { return match.GetCount() ; } ///< Returns the number of different recognition sequences
+{
+  public :
+    TProtease ( const wxString& _name = _T("") , const wxString& m = _T("") , const wxString& _note = _T("") ) ; ///< Constructor
+    bool does_match ( const wxString& s ) ; ///< Does this protease recognize this sequence?
+    inline int len() const { return match.GetCount() ; } ///< Returns the number of different recognition sequences
     wxString name ; ///< The name of the protease
     wxArrayString match ; ///< The different recognition sequences
     int cut ; ///< Where the cut occurs, starting at 0
@@ -101,16 +101,16 @@ class TProtease
     
     /// A note about the protease
     wxString note , str_match ;
-    } ;
+} ;
 
 /// \brief Class to store a protease cut
 class TProteaseCut
-    {
-    public :
+{
+  public :
     TProtease *protease ; ///< Pointer to the protease
     int cut ; ///< Position of the cut
     bool left ; ///< Left or right from the given position?
-    } ;
+} ;
     
 
 #endif

--- a/SCFtype.cpp
+++ b/SCFtype.cpp
@@ -104,7 +104,7 @@ SCFtype::SCFtype ()
 	{
 	}
 
-bool SCFtype::parse ( wxString filename )
+bool SCFtype::parse ( const wxString& filename )
 	{
 	wxFile f ( filename , wxFile::read ) ;
 	long l = f.Length() ;
@@ -114,12 +114,11 @@ bool SCFtype::parse ( wxString filename )
 	
 	if ( *(t+0) != '.' || *(t+1) != 's' || *(t+2) != 'c' || *(t+3) != 'f' )
 		{
-		delete t ;
+		delete [] t ;
 		return false ; // No luck
 		}
 	
 	SCF_Header *header = (SCF_Header*) t ;
-
 
 	wxString version ;
 	version += (*header).version[0] ;
@@ -129,6 +128,7 @@ bool SCFtype::parse ( wxString filename )
 	if ( (*header).version[0] < '3' )
 		{
 		wxMessageBox ( _T("Cannot read SFC prior to 3.0, this is ") + version ) ;
+                delete [] t;
 		return false ;
 		}
 

--- a/SCFtype.h
+++ b/SCFtype.h
@@ -10,7 +10,7 @@ class SCFtype
 	{
 	public :
 	SCFtype () ;
-	bool parse ( wxString filename ) ;
+	bool parse ( const wxString& filename ) ;
 	
 	TSequencerData sd ;
 	

--- a/SequenceTypeRestriction.cpp
+++ b/SequenceTypeRestriction.cpp
@@ -207,7 +207,7 @@ void SeqRestriction::show ( wxDC& dc )
                qlx = x ;
                if ( b == pl.getTo ( idx ) )
                   {
-                  wxString t = rc->getDisplayName() ;
+                  const wxString t = rc->getDisplayName() ;
                   if ( down ) dc.DrawText ( t , llx , ly - ch2 ) ;
                   else dc.DrawText ( t , llx , ly ) ;
                   }

--- a/TCalculator.cpp
+++ b/TCalculator.cpp
@@ -150,7 +150,7 @@ void TCalculator::initme ()
     Activate () ;
     }
 
-wxString TCalculator::getName ()
+const wxString TCalculator::getName () const
     {
     return txt("t_calculator") ;
     }

--- a/TCalculator.h
+++ b/TCalculator.h
@@ -104,7 +104,7 @@ class TCalculator : public ChildBase
     ~TCalculator () ; ///< Destructor
     
     void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
 
 //    virtual void OnClose(wxCloseEvent& event) ;
     virtual void OnSeqPrint(wxCommandEvent& event) ; ///< Print event handler

--- a/TDotPlot.cpp
+++ b/TDotPlot.cpp
@@ -141,7 +141,7 @@ void TDotPlot::initme ()
     update_sequence_lists() ;
 }
 
-wxString TDotPlot::getName ()
+const wxString TDotPlot::getName () const
 {
     return txt("t_dotplot") ;
 }

--- a/TDotPlot.h
+++ b/TDotPlot.h
@@ -52,7 +52,7 @@ class TDotPlot : public ChildBase
     ~TDotPlot () ; ///< Destructor
         
     void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
 
     virtual void OnZoom(wxScrollEvent& event); ///< Zoom event handler
     virtual void OnDummy(wxCommandEvent& WXUNUSED(event)){}; ///< Dummy event handler

--- a/TGraph.cpp
+++ b/TGraph.cpp
@@ -130,7 +130,7 @@ void TGraph::initme ()
     gd->SetFocus() ;
 	}
 
-wxString TGraph::getName ()
+const wxString TGraph::getName () const
 	{
     return txt("t_graph") ;
 	}

--- a/TGraph.h
+++ b/TGraph.h
@@ -157,7 +157,7 @@ class TGraph : public ChildBase
     ~TGraph () ; ///< Destructor
         
     void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the module name
+    virtual const wxString getName () const ; ///< Returns the module name
 
     virtual void OnZoomX(wxScrollEvent& event); ///< Zoom event handler
     virtual void OnZoomY(wxScrollEvent& event); ///< Zoom event handler

--- a/TImageDisplay.cpp
+++ b/TImageDisplay.cpp
@@ -241,7 +241,7 @@ void TImageDisplay::OnCBinvert ( wxCommandEvent &event )
 	right->Refresh () ;
 	}    
 
-wxString TImageDisplay::getName ()
+const wxString TImageDisplay::getName () const
     {
     return _T("Image Viewer") ;
     }

--- a/TImageDisplay.h
+++ b/TImageDisplay.h
@@ -25,7 +25,7 @@ class TImageDisplay : public ChildBase
     ~TImageDisplay () ; ///< Destructor
     
     void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the image module name
+    virtual const wxString getName () const ; ///< Returns the image module name
 
     virtual void OnCB ( wxCommandEvent &event ) ; ///< Show labels event handler
     virtual void OnCBinvert ( wxCommandEvent &event ) ; ///< Invert image event handler

--- a/TPhyloTree.cpp
+++ b/TPhyloTree.cpp
@@ -112,7 +112,7 @@ void TPhyloTree::initme ()
 	Show () ;
 	}
 
-wxString TPhyloTree::getName()
+const wxString TPhyloTree::getName() const
 	{
 	return _T("Phylogenetic tree") ;
 	}
@@ -174,7 +174,8 @@ void TPhyloTree::setRealNames ( TAlignment *ali )
 	
 	for ( a = 0 ; a < vt.size() ; a++ )
 		{
-		wxString vn = vt[a]->getName().Trim().Trim(true) ;
+		wxString _vn = vt[a]->getName();
+		wxString vn = _vn.Trim().Trim(true) ;
 		if ( vn == _T("") ) continue ;
 		for ( b = 0 ; b < ali->lines.size() ; b++ )
 			{

--- a/TPhyloTree.h
+++ b/TPhyloTree.h
@@ -14,7 +14,7 @@ class TPTree
 	virtual void setWeight ( double w ) { weight = w ; }
 	virtual void setName ( wxString n ) { name = n ; }
 	virtual float getWeight () { return weight ; }
-	virtual wxString getName () { return name ; }
+	virtual const wxString getName () const { return name ; }
 	virtual bool isLeaf () { return children.size() == 0 ; }
 	virtual double getMaxWeight () ;
 	virtual double getCurrentWeight () ;
@@ -50,7 +50,7 @@ class TPhyloTree : public ChildBase
     TPhyloTree(wxWindow *parent, const wxString& title) ; ///< Constructor
     
     virtual void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the gel module name
+    virtual const wxString getName () const ; ///< Returns the gel module name
     
     virtual void setNewickTrees ( wxString s , TAlignment *_ali = NULL ) ;
     virtual void setModeStrange () ;

--- a/TPrimer.cpp
+++ b/TPrimer.cpp
@@ -23,8 +23,8 @@ float TPrimer::getTm ( int type )
     return 0 ;
     }
     
-wxString TPrimer::getName () { return name ; }    
-void TPrimer::setName ( wxString nn ) { name = nn ; }    
+const wxString TPrimer::getName () const { return name ; }    
+void TPrimer::setName ( const wxString& nn ) { name = nn ; }    
 float TPrimer::getEvaluation () { return evaluation ; }
 float TPrimer::getGCcontents () { return pgc ; }
 

--- a/TPrimer.h
+++ b/TPrimer.h
@@ -43,8 +43,8 @@ class TPrimer
     float getEvaluation () ; ///< Get quality evaluation (for annealing)
     float getGCcontents () ; ///< Get GC contents
     
-    wxString getName () ; ///< Returns the name of the primer, if any was given
-    void setName ( wxString nn ) ; ///< Sets the name of the primer
+    const wxString getName () const ; ///< Returns the name of the primer, if any was given
+    void setName ( const wxString& nn ) ; ///< Sets the name of the primer
     
     
     // Variables

--- a/TRestrictionIdentifier.cpp
+++ b/TRestrictionIdentifier.cpp
@@ -45,7 +45,7 @@ TRestrictionIdentifier::TRestrictionIdentifier(wxWindow *parent, const wxString&
     running = false ;
 }
 
-wxString TRestrictionIdentifier::getName ()
+const wxString TRestrictionIdentifier::getName () const
     {
     return _T("Restriction Identifier") ;
     }

--- a/TVector.cpp
+++ b/TVector.cpp
@@ -14,37 +14,115 @@ vector <TAAProp> TVector::aaprop ;
 wxArrayString TVector::codon_tables ;
 wxArrayString TVector::codon_table_names ;
 
-void TVector::setWindow ( ChildBase *c ) { window = c ; }
-void TVector::setCircular ( bool c ) { circular = c ; }
-bool TVector::isCircular () { return circular ; }
-bool TVector::isLinear () { return !circular ; }
-bool TVector::hasStickyEnds () { return (_lu+_ll+_ru+_rl!=_T("")) ; }
-float TVector::getAAmw ( char aa ) { return aaprop[aa].mw ; }
-float TVector::getAApi ( char aa ) { return aaprop[aa].pi ; }
-char TVector::getComplement ( char c ) { return COMPLEMENT[c] ; }
-TAAProp TVector::getAAprop ( char a ) { return aaprop[a] ; }
-void TVector::setGenomeMode ( bool gm ) { genomeMode = gm ; }
-bool TVector::getGenomeMode () { return genomeMode ; }
+void TVector::setWindow ( ChildBase * const c ) { window = c ; }
+void TVector::setCircular ( const bool c ) { circular = c ; }
+bool TVector::isCircular () const { return circular ; }
+bool TVector::isLinear () const { return !circular ; }
+bool TVector::hasStickyEnds () const { return (_lu+_ll+_ru+_rl!=_T("")) ; }
+float TVector::getAAmw ( char aa ) const { return aaprop[aa].mw ; }
+float TVector::getAApi ( char aa ) const { return aaprop[aa].pi ; }
+char TVector::getComplement ( const char c ) const { return COMPLEMENT[c] ; }
+TAAProp TVector::getAAprop ( const char a ) const { return aaprop[a] ; }
+void TVector::setGenomeMode ( const bool gm ) { genomeMode = gm ; }
+bool TVector::getGenomeMode () const { return genomeMode ; }
 wxString *TVector::getSequencePointer () { return &sequence ; }
-TORF *TVector::getORF ( int a ) { return &worf[a] ; }
+TORF *TVector::getORF ( const int a ) { return &worf[a] ; }
 int TVector::countORFs () { return worf.size() ; }
 void TVector::updateDisplay ( bool update ) { recalcvisual = update ; }
 bool TVector::displayUpdate () { return recalcvisual ; }
-void TVector::setType ( int newtype ) { type = newtype ; }
-int TVector::getType () { return type ; }
-int TVector::getMethylationSiteIndex ( int pos ) { return methyl.Index ( pos ) ; }
-int TVector::getMethylationSite ( int index ) { return methyl[index] ; }
-int TVector::countMethylationSites () { return methyl.GetCount() ; }
-TEnzymeRules *TVector::getEnzymeRules () { return enzyme_rules ; }
-void TVector::setEnzymeRules ( TEnzymeRules *er ) { enzyme_rules = er ; }
-int TVector::countCodonTables () { return codon_table_names.size() ; }
-wxString TVector::getCodonTableName ( int x ) { return codon_table_names[x] ; }
+void TVector::setType ( const int newtype ) { type = newtype ; }
+int TVector::getType () const { return type ; }
+int TVector::getMethylationSiteIndex ( const int pos ) const { return methyl.Index ( pos ) ; }
+int TVector::getMethylationSite ( const int index ) const { return methyl[index] ; }
+int TVector::countMethylationSites () const { return methyl.GetCount() ; }
+TEnzymeRules *TVector::getEnzymeRules () const { return enzyme_rules ; }
+void TVector::setEnzymeRules ( TEnzymeRules * const er ) { enzyme_rules = er ; }
+int TVector::countCodonTables () const { return codon_table_names.size() ; }
+wxString TVector::getCodonTableName ( const int x ) const { return codon_table_names[x] ; }
 void TVector::resetTurn () { turned = 0 ; }
 
+/*TVector::TVector ( const TVector& original)
+{
+    fprintf(stderr,"Debug: TVector copy constructor called.\n");
+    for ( int a = 0 ; a < items.size() ; a++ ) items[a].setLastVector ( &original ) ;
+    undo.clear () ;
+}
+*/
 
-void TVector::prepareFeatureEdit ( int pos , bool overwrite )
-	{
+/*
+TVector& operator=(const TVector& other)
+{
+    // Guard self assignment
+    if (this == &other)
+        return *this;
+ 
+    type=other.type ; ///< The sequence type
+    enzyme_rules=other.enzyme_rules ; ///< Pointer to the restriction enzyme display rules
+    recalcvisual=other.recalcvisual ; ///< Recalculate the layout of the sequence?
+    worf=other.worf ; ///< Open Reading Frames
+    methyl=other.methyl ; ///< Methylation sites
+    hiddenEnzymes=other.hiddenEnzyes ; ///< Enzymes that are not shown
+    sequence=other.sequence ; ///< The sequence that all this fuss is about
+    _lu=other._lu ;  ///< Left upper sticky end
+    _ll=other._ll ; ///< Left lower sticky end
+    _ru=other._ru ; ///< Right upper sticky end
+    _rl=other._rl ; ///< Right lower sticky end
+    name=other.name ; ///< The name of the sequence
+    desc=other.desc ; ///< The sequence description
+    circular=other.circular ; ///< Is this sequence circular?
+    changed=other.changed ; ///< Was this sequence changed?
+    genomeMode=other.genomeMode ; ///< Is this a genome (using different display routines)?
+    window=other.window ; ///< The window this TVector belongs to (might be NULL for most methods)
+    turned=other.turned ; ///< A circular sequence can be turned; this is the number of bases (negative for "left")
+    action_value=other.action_value ; ///< Used by doAction()
+    database=other.database ; ///< The database this vector was loaded from
+    action=other.action ; ///< Used by doAction()
+    aa=other.aa ; ///< Hell if I remember what this is for
+ 
+    return *this;
+}
+*/
+
+void TVector::setFromVector ( const TVector &other )
+    {
+#if 0
+    *this = other ;
+#else
+    type=other.type ; ///< The sequence type
+    enzyme_rules=other.enzyme_rules ; ///< Pointer to the restriction enzyme display rules
+    recalcvisual=other.recalcvisual ; ///< Recalculate the layout of the sequence?
+    worf=other.worf ; ///< Open Reading Frames
+    methyl=other.methyl ; ///< Methylation sites
+    hiddenEnzymes=other.hiddenEnzymes ; ///< Enzymes that are not shown
+    sequence=other.sequence ; ///< The sequence that all this fuss is about
+    _lu=other._lu ;  ///< Left upper sticky end
+    _ll=other._ll ; ///< Left lower sticky end
+    _ru=other._ru ; ///< Right upper sticky end
+    _rl=other._rl ; ///< Right lower sticky end
+    name=other.name ; ///< The name of the sequence
+    desc=other.desc ; ///< The sequence description
+    circular=other.circular ; ///< Is this sequence circular?
+    changed=other.changed ; ///< Was this sequence changed?
+    genomeMode=other.genomeMode ; ///< Is this a genome (using different display routines)?
+    window=other.window ; ///< The window this TVector belongs to (might be NULL for most methods)
+    turned=other.turned ; ///< A circular sequence can be turned; this is the number of bases (negative for "left")
+    action_value=other.action_value ; ///< Used by doAction()
+    database=other.database ; ///< The database this vector was loaded from
+    action=other.action ; ///< Used by doAction()
+    aa=other.aa ; ///< Hell if I remember what this is for
+ 
+#endif
+
+    for ( int a = 0 ; a < items.size() ; a++ ) items[a].setLastVector ( this ) ;
+    undo.clear () ;
+    }
+
+
+void TVector::prepareFeatureEdit ( const int _pos , const bool overwrite )
+{
 	int mode = myapp()->frame->editFeatureMode ;
+        int pos = _pos;
+
 	if ( mode == 0 ) return ; // Keep as is
 	
 	int a ;
@@ -98,7 +176,7 @@ void TVector::prepareFeatureEdit ( int pos , bool overwrite )
 		}    
 	}    
 
-void TVector::getItemsAtPosition ( int pos , wxArrayInt &vi , bool limit )
+void TVector::getItemsAtPosition ( const int pos , wxArrayInt &vi , const bool limit ) const
 	{
 	vi.clear () ;
 	int a ;
@@ -116,19 +194,19 @@ void TVector::getItemsAtPosition ( int pos , wxArrayInt &vi , bool limit )
 		}
 	}
 
-bool TVector::hasItemsAtPosition ( int pos )
+bool TVector::hasItemsAtPosition ( const int pos ) const
 	{
 	wxArrayInt vi ;
 	getItemsAtPosition ( pos , vi , true ) ;
 	return vi.size() > 0 ;
 	}
 
-wxString TVector::getStrand53 ()
+wxString TVector::getStrand53 () const
 	{
 	return _lu + sequence + _ru ;
 	}
      
-wxString TVector::getStrand35 ()
+wxString TVector::getStrand35 () const
 	{
 	wxString t1 , t2 , t3 ;
 	int a ;
@@ -138,14 +216,14 @@ wxString TVector::getStrand35 ()
 	return t1 + t2 + t3 ;
 	}
      
-int TVector::showGC () // Return 0 for "no", otherwise number of blocks
+int TVector::showGC () const // Return 0 for "no", otherwise number of blocks
 	{
     if ( type == TYPE_AMINO_ACIDS ) return 0 ;
 	int r = getSequenceLength() / 5 ;
 	return getEnzymeRule()->showgc ? ( r > 400 ? 400 : r ) : 0 ;
 	}    
 
-wxString TVector::getParams ()
+wxString TVector::getParams () const
 	{
 	wxString params ;
 	for ( int a = 0 ; a < paramk.GetCount() ; a++ )
@@ -156,7 +234,7 @@ wxString TVector::getParams ()
     return params ;
     }
     
-wxString TVector::getParam ( wxString key )
+const wxString TVector::getParam ( const wxString& key ) const
 	{
 	int a ;
 	for ( a = 0 ; a < paramk.GetCount() && paramk[a] != key ; a++ ) ;
@@ -164,7 +242,7 @@ wxString TVector::getParam ( wxString key )
 	else return paramv[a] ;
 	}
      
-void TVector::setParam ( wxString key , wxString value )
+void TVector::setParam ( const wxString& key , const wxString& value )
 	{
 	int a ;
 	for ( a = 0 ; a < paramk.GetCount() && paramk[a] != key ; a++ ) ;
@@ -177,10 +255,11 @@ void TVector::setParam ( wxString key , wxString value )
 	evaluate_key_value ( key , value ) ;
 	}    
 
-void TVector::setParams ( wxString t )
+void TVector::setParams ( const wxString& _t )
 	{
 	paramk.Clear () ;
 	paramv.Clear () ;
+        wxString t=_t;
 	if ( t.IsEmpty() || t.GetChar(0) != '#' ) t = _T("#genbank\n") + t ; // Backwards compatability
 	wxArrayString vs ;
 	explode ( _T("\n") , t , vs ) ;
@@ -198,7 +277,7 @@ void TVector::setParams ( wxString t )
 		evaluate_key_value ( paramk[a] , paramv[a] ) ;
     }
     
-void TVector::evaluate_key_value ( wxString key , wxString value )
+void TVector::evaluate_key_value ( const wxString& key , const wxString& value )
 	{
 	if ( key == _T("enzymerule") )
 		{
@@ -209,7 +288,7 @@ void TVector::evaluate_key_value ( wxString key , wxString value )
 		}    
 	}    
 
-void TVector::methylationSites ( wxArrayInt &vi , int what )
+void TVector::methylationSites ( wxArrayInt &vi , const int what )
 	{
 	vi.Clear () ;
 	int a ;
@@ -238,7 +317,7 @@ void TVector::methylationSites ( wxArrayInt &vi , int what )
 		}    
 	}    
 
-TVector *TVector::newFromMark ( int from , int to ) 
+TVector *TVector::newFromMark ( const int from , const int to )  const
     {
 //    char t[1000] ;
     TVector *nv = new TVector ;
@@ -268,22 +347,24 @@ TVector *TVector::newFromMark ( int from , int to )
     return nv ;
     }
     
-void TVector::setNucleotide ( int pos , char t )
+void TVector::setNucleotide ( const int _pos , const char t )
     {
     int sl = sequence.length() ;
-    if ( isLinear() && ( pos < 0 || pos >= sl ) ) return ;
+    if ( isLinear() && ( _pos < 0 || _pos >= sl ) ) return ;
+
+    int pos=_pos;
     while ( pos < 0 ) pos += sl ;
     while ( pos >= sequence.length() ) pos -= sl ;
 //    insert_char ( t , pos+1 , true ) ;
     sequence.SetChar(pos,t);
     }    
 
-bool TVector::basematch ( char b1 , char b2 ) // b1 in IUPAC, b2 in SIUPAC
+bool TVector::basematch ( const char b1 , const char b2 ) const // b1 in IUPAC, b2 in SIUPAC
    {
    return b1 == b2 || ( ( IUPAC[b1] & SIUPAC[b2] ) > 0 ) ;
    }
    
-wxString TVector::vary_base ( char b )
+wxString TVector::vary_base ( const char b ) const
     {
     wxString ret ;
     if ( basematch ( 'A' , b ) ) ret += 'A' ;
@@ -293,13 +374,13 @@ wxString TVector::vary_base ( char b )
     return ret ;
     }    
 
-wxString TVector::one2three ( int a )
+const wxString TVector::one2three ( const int a ) const
     {
     if ( a < 0 || a > 255 ) return _T("") ;
     return aaprop[a].tla ;
     }
     
-void TVector::setStickyEnd ( bool left , bool upper , wxString s )
+void TVector::setStickyEnd ( const bool left , const bool upper , const wxString& s )
     {
     if ( left && upper ) _lu = s ;
     else if ( left && !upper ) _ll = s ;
@@ -335,7 +416,7 @@ TVector::~TVector ()
     undo.clear () ;
     }
     
-void TVector::setCodonTable ( int table , wxString sequence , wxString name )
+void TVector::setCodonTable ( const int table , const wxString& sequence , const wxString& name )
     {
     while ( codon_tables.GetCount() <= table ) codon_tables.Add ( _T("") ) ;
     while ( codon_table_names.GetCount() <= table ) codon_table_names.Add ( _T("") ) ;
@@ -553,7 +634,7 @@ void TVector::init ()
     for ( a = 'a' ; a <= 'z' ; a++ ) aaprop[a] = aaprop[a-'a'+'A'] ;
 }    
     
-void TVector::makeAA2DNA ( wxString mode )
+void TVector::makeAA2DNA ( const wxString& mode ) // not const
     {
     int a , b , c ;
 	wxString iu = _T("ACGT") ;
@@ -838,7 +919,7 @@ bool TVector::getVectorCuts ( TVector *v )
 	}    
 	
 // Gets the enzyme rules to follow
-TEnzymeRules *TVector::getEnzymeRule ()
+TEnzymeRules *TVector::getEnzymeRule () const
 	{
 	TEnzymeRules *er ;
 	if ( enzyme_rules ) // Vector settings
@@ -951,17 +1032,18 @@ bool TVector::reduceToFragment ( TRestrictionCut left , TRestrictionCut right )
     return true ; // Success; actually, no "return false" yet.
     }
     
-char TVector::getNucleotide ( int pos , bool complement )
+char TVector::getNucleotide ( const int _pos ,  const bool complement ) const
     {
     int sl = sequence.length() ;
-    if ( isLinear() && ( pos < 0 || pos >= sl ) ) return ' ' ;
+    if ( isLinear() && ( _pos < 0 || _pos >= sl ) ) return ' ' ;
+    int pos = _pos;
     while ( pos < 0 ) pos += sl ;
     while ( pos >= sl ) pos -= sl ;
     if ( complement ) return getComplement ( sequence.GetChar(pos) ) ;
     return sequence.GetChar(pos) ;
     }
     
-wxString TVector::transformSequence ( bool inverse , bool reverse )
+wxString TVector::transformSequence ( const bool inverse , const bool reverse ) const
     {
     int a ;
     wxString r = sequence ;
@@ -1088,7 +1170,7 @@ void TVector::doAction ()
     return ;
     }
     
-wxString TVector::invert ( wxString s )
+wxString TVector::invert ( const wxString& s ) const
     {
     wxString t ;
     for ( int a = 0 ; a < s.length() ; a++ ) t = s.GetChar(a) + t ;
@@ -1222,7 +1304,7 @@ void TVector::doRemove ( int from , int to , bool update , bool enableUndo )
     else if ( enableUndo ) undo.abort () ;
     }
 
-wxString TVector::get_translation_table ( int translation_table )
+wxString TVector::get_translation_table ( const int translation_table ) const
 	{
 	wxString ret ;
 	if ( myapp()->frame->nonstandard_translation_table != -1 ) // Forced translation table
@@ -1234,10 +1316,11 @@ wxString TVector::get_translation_table ( int translation_table )
     
 // Currently returns only the direct encoding (a single char) or 'X'
 // Could return all possible AAs (see IUPAC) in the future
-wxString TVector::dna2aa ( wxString codon , int translation_table )
+wxString TVector::dna2aa ( const wxString& codon , const int translation_table ) const
     {
     if ( codon.length() != 3 ) return _T("?") ;
-    wxString r , aa = get_translation_table ( translation_table ) ;
+    wxString r;
+    const wxString aa = get_translation_table ( translation_table ) ;
     char c0 = codon.GetChar(0) ;
     char c1 = codon.GetChar(1) ;
     char c2 = codon.GetChar(2) ;
@@ -1278,7 +1361,7 @@ wxString TVector::dna2aa ( wxString codon , int translation_table )
     return r ;
     }
     
-void TVector::turn ( int off )
+void TVector::turn ( const int off )
 	{
 	// Allowing turn of linear fragments as a temporary measure due to a problem in getAAvector
 	//if ( !circular ) return ;
@@ -1301,8 +1384,8 @@ void TVector::turn ( int off )
 	// Sequence
 	if ( off > 0 )
 		{
-		off = sequence.length() - off ;
-		sequence = sequence.substr ( off ) + sequence.substr ( 0 , off ) ;
+		const int off_diff = sequence.length() - off ;
+		sequence = sequence.substr ( off_diff ) + sequence.substr ( 0 , off_diff ) ;
 		}
 	else
 		{
@@ -1315,7 +1398,7 @@ void TVector::turn ( int off )
 	turned += off ;
 	}
     
-int TVector::countCuts ( wxString enzyme )
+int TVector::countCuts ( const wxString& enzyme ) const
     {
     int a , count ;
     for ( a = count = 0 ; a < rc.size() ; a++ )
@@ -1324,7 +1407,7 @@ int TVector::countCuts ( wxString enzyme )
     return count ;
     }
         
-void TVector::setAction ( wxString _action , int _action_value )
+void TVector::setAction ( const wxString& _action , const int _action_value )
     {
     action = _action ;
     action_value = _action_value ;
@@ -1348,7 +1431,7 @@ wxString TVector::getSubstring ( int mf , int mt )
         }
     }
     
-void TVector::setChanged ( bool c )
+void TVector::setChanged ( const bool c )
     {
     if ( c == changed ) return ;
     changed = c ;
@@ -1418,13 +1501,17 @@ void TVector::addORFs ( int off )
         }
     }
     
-TVector *TVector::getAAvector ( int from , int to , int dir )
+TVector *TVector::getAAvector ( const int _from , const int _to , const int dir ) const
     {
     char UNIQUE = '#' ;
     // Creating new vector
     TVector *v = new TVector ;
     v->setFromVector ( *this ) ;
     v->setType ( TYPE_AMINO_ACIDS ) ;
+
+    // FIXME: Should be const but is not, maybe be more restrictive with from<to ?
+    int to = _to;
+    int from = _from;
 
     if ( to < from ) to += v->sequence.length() ;
     v->turn ( -from+1 ) ;
@@ -1514,13 +1601,6 @@ void TVector::callUpdateUndoMenu ()
     window->updateUndoMenu() ;
     }
     
-void TVector::setFromVector ( TVector &v )
-    {
-    *this = v ;
-    for ( int a = 0 ; a < items.size() ; a++ ) items[a].setLastVector ( this ) ;
-    undo.clear () ;
-    }
-
 int TVector::getItemLength ( int a )
     {
     if ( items[a].to >= items[a].from ) return items[a].to - items[a].from + 1 ;
@@ -1553,7 +1633,7 @@ void TVector::clear ()
     proteases.Clear () ;
     }
     
-int TVector::find_item ( wxString s )
+int TVector::find_item ( const wxString& s ) const
     {
     int a ;
     for ( a = 0 ; a < items.size() ; a++ )
@@ -1562,7 +1642,7 @@ int TVector::find_item ( wxString s )
     return -1 ; // Not found
     }
     
-bool TVector::isEnzymeHidden ( wxString s )
+bool TVector::isEnzymeHidden ( const wxString& s ) const
     {
     int a ;
     for ( a = 0 ; a < hiddenEnzymes.GetCount() ; a++ )
@@ -1570,7 +1650,7 @@ bool TVector::isEnzymeHidden ( wxString s )
     return false ;
     }
 
-void TVector::hideEnzyme ( wxString s , bool hideit )
+void TVector::hideEnzyme ( const wxString& s , const bool hideit )
 	{
 	bool isHidden = isEnzymeHidden ( s ) ;
 	if ( hideit && !isHidden ) // Add enzymes to hidden enzyme list
@@ -1598,79 +1678,79 @@ void TVector::sortRestrictionSites ()
         }
     }
     
-wxString TVector::getDescription ()
+const wxString TVector::getDescription () const
     {
     return desc ;
     }    
     
-void TVector::setDescription ( wxString s )
+void TVector::setDescription ( const wxString& s )
     {
     desc = s ;
     }
     
-void TVector::addDescription ( wxString s )
+void TVector::addDescription ( const wxString& s )
     {
     desc += s ;
     }
     
-wxString TVector::getName ()
+const wxString TVector::getName () const
     {
     return name ;
     }    
     
-void TVector::setName ( wxString s )
+void TVector::setName ( const wxString& s )
     {
     name = s ;
     }
     
-void TVector::addName ( wxString s )
+void TVector::addName ( const wxString& s )
     {
     name += s ;
     }
     
-wxString TVector::getSequence ()
+wxString TVector::getSequence () const
     {
     return sequence ;
     }
     
-void TVector::removeAlignmentArtifacts ( char what )
+void TVector::removeAlignmentArtifacts ( const char what )
     {
     wxString what2 ( (wxChar) what ) ;
     sequence.Replace ( what2 , _T("") ) ;
     }    
     
-char TVector::getSequenceChar ( int x )
+char TVector::getSequenceChar ( const int x ) const
     {
     return sequence.GetChar(x) ;
     }    
         
-void TVector::setSequence ( wxString ns )
+void TVector::setSequence ( const wxString& ns )
     {
     sequence.Alloc ( ns.length() + 10 ) ;
     sequence = ns ;
     }    
     
-void TVector::addToSequence ( wxString x )
+void TVector::addToSequence ( const wxString& x )
     {
     sequence.Append ( x ) ;
     }    
     
-void TVector::alterSequence ( int pos , char c )
+void TVector::alterSequence ( const int pos , const char c )
     {
     sequence.SetChar ( pos , c ) ;
     }    
     
-int TVector::getSequenceLength()
+int TVector::getSequenceLength() const
     {
     return sequence.length() ;
     }    
     
-void TVector::eraseSequence ( int from , int len )
+void TVector::eraseSequence ( const int from , const int len )
     {
     sequence.erase ( from , len ) ;
     }    
     
-char TVector::three2one ( wxString s )
+char TVector::three2one ( wxString s ) const
     {
     s.MakeUpper() ;
     int a ;
@@ -1683,7 +1763,7 @@ char TVector::three2one ( wxString s )
     }    
     
 // "Back-translate" amino acid sequence to DNA
-TVector *TVector::backtranslate ( wxString mode )
+TVector *TVector::backtranslate ( const wxString& mode ) // not const becaues of makeAA2DNA
     {
     TVector *nv = new TVector ;
     nv->setFromVector ( *this ) ;
@@ -1705,7 +1785,7 @@ TVector *TVector::backtranslate ( wxString mode )
     return nv ;
     }    
 
-int TVector::getMem ()
+int TVector::getMem () const
     {
     int a , r = 0 ;
     for ( a = 0 ; a < items.size() ; a++ ) r += items[a].getMem() ;
@@ -1721,7 +1801,7 @@ int TVector::getMem ()
     return r ;
     }    
 
-void TVector::addRestrictionEnzyme ( TRestrictionEnzyme *e )
+void TVector::addRestrictionEnzyme ( TRestrictionEnzyme * const e )
 	{
 	for ( int a = 0 ; a < re.size() ; a++ )
 		{
@@ -1739,7 +1819,7 @@ TVectorItem::TVectorItem()
     initParams () ;
     }
 
-TVectorItem::TVectorItem ( wxString sn , wxString n , int f , int t , char ty = VIT_MISC )
+TVectorItem::TVectorItem ( const wxString& sn , const wxString& n , const int f , const int t , const char ty = VIT_MISC )
     {
     initParams () ;
     name = sn ;
@@ -1751,7 +1831,7 @@ TVectorItem::TVectorItem ( wxString sn , wxString n , int f , int t , char ty = 
     r3 = r4 = -1 ;
     }
 
-wxBrush *TVectorItem::getBrush ()
+wxBrush *TVectorItem::getBrush () const
     {
     if ( getParam ( _T("ISDEFAULTBRUSH") ) == _T("1") )
         {
@@ -1772,7 +1852,7 @@ wxBrush *TVectorItem::getBrush ()
         }
     }
 
-wxColour TVectorItem::getFontColor ()
+wxColour TVectorItem::getFontColor () const
     {
     wxBrush *b = getBrush() ;
     myass ( b , "Brush is NULL!" ) ;
@@ -1782,18 +1862,18 @@ wxColour TVectorItem::getFontColor ()
     return c ;
     }
     
-bool TVectorItem::isVisible ()
+bool TVectorItem::isVisible () const
     {
     wxString s = getParam ( _T("ISVISIBLE") ) ;
     return ( s == _T("1") ) ;
     }
     
-void TVectorItem::setVisible ( bool b )
+void TVectorItem::setVisible ( const bool b )
     {
     setParam ( _T("ISVISIBLE") , b ) ;
     }
     
-void TVectorItem::setColor ( wxColour col )
+void TVectorItem::setColor ( const wxColour& col )
     {
     setParam ( _T("ISDEFAULTBRUSH") , false ) ;
     setParam ( _T("COLOR_RED") , col.Red() ) ;
@@ -1803,7 +1883,7 @@ void TVectorItem::setColor ( wxColour col )
     
 //********************* PARAMS
 
-void TVectorItem::setParam ( wxString p , wxString v )
+void TVectorItem::setParam ( const wxString& p , const wxString& v )
     {
     int a = pname.Index ( p ) ;
     if ( a == wxNOT_FOUND )
@@ -1814,18 +1894,18 @@ void TVectorItem::setParam ( wxString p , wxString v )
     else pvalue[a] = v ;
     }
     
-void TVectorItem::setParam ( wxString p , int v )
+void TVectorItem::setParam ( const wxString& p , const int v )
     {
     setParam ( p , wxString::Format ( _T("%d") , v ) ) ;
     }
     
-wxString TVectorItem::getParam ( wxString p , wxString def )
+const wxString TVectorItem::getParam ( const wxString& p , const wxString& def ) const
     {
     int a = pname.Index ( p ) ;
     return ( a == wxNOT_FOUND ) ? def : pvalue[a] ;
     }
     
-wxArrayString TVectorItem::getParamKeys ()
+wxArrayString TVectorItem::getParamKeys () const
     {
     return pname ;
     }
@@ -1846,7 +1926,7 @@ wxString TVectorItem::implodeParams ()
     return s ;
     }
 
-void TVectorItem::explodeParams ( wxString _s )
+void TVectorItem::explodeParams ( const wxString& _s )
     {
     wxString s = _s ;
     int a ;
@@ -1882,7 +1962,7 @@ void TVectorItem::initParams ()
     lastVector = NULL ;
     }
 
-int TVectorItem::getRF ()
+int TVectorItem::getRF () const
     {
     if ( type != VIT_CDS ) return 0 ;
 	long l ;
@@ -1890,13 +1970,13 @@ int TVectorItem::getRF ()
 	return (int) l ;
     }
     
-void TVectorItem::setRF ( int x )
+void TVectorItem::setRF ( const int x )
     {
     if ( type != VIT_CDS ) return ;
     setParam ( _T("/codon_start") , x ) ;
     }
     
-void TVectorItem::doRemove ( int f , int t , int l )
+void TVectorItem::doRemove ( const int f , const int t , const int l )
     {
     if ( from == -1 ) return ;
     int rt = t ;
@@ -1921,29 +2001,31 @@ void TVectorItem::doRemove ( int f , int t , int l )
           }
        }
     to += from ;
-    l -= rt - f + 1 ;
-    if ( l == 0 ) 
+
+    const int l_mod = l - rt - f + 1 ;
+    if ( l_mod == 0 ) 
         {
         from = -1 ;
         return ;
         }
-    while ( to > l ) to -= l ;
-    while ( from > l ) from -= l ;
+    while ( to > l_mod ) to -= l_mod ;
+    while ( from > l_mod ) from -= l_mod ;
+
     }
     
-int TVectorItem::getOffset ()
+int TVectorItem::getOffset () const
     {
     return atoi ( getParam ( _T("OFFSET") , _T("-1") ).mb_str() ) ;
     }
     
-void TVectorItem::setOffset ( int o )
+void TVectorItem::setOffset ( const int o )
     {
     setParam ( _T("OFFSET") , o ) ;
     }
     
-void TVectorItem::setType ( wxString s )
+void TVectorItem::setType ( const wxString& _s )
     {
-    s = s.MakeUpper() ;
+    wxString s = _s.Upper() ;
     if ( s == _T("CDS") ) type = VIT_CDS ;
     else if ( s == _T("GENE") ) type = VIT_GENE ;
     else if ( s == _T("PROMOTER") ) type = VIT_PROMOTER ;
@@ -1964,9 +2046,9 @@ void TVectorItem::setType ( wxString s )
     }
     
 
-void TVectorItem::translate ( TVector *v , SeqAA *aa , vector <Tdna2aa> &dna2aa )
+void TVectorItem::translate ( const TVector * const v , SeqAA * const aa , vector <Tdna2aa> &dna2aa ) // not const
    {
-   lastVector = v ;
+   lastVector = v ; // -> translate is not const because of this assignment
 //   dna2aa.clear () ;
    if ( type != VIT_CDS ) return ;
    if ( getRF() == 0 ) return ;
@@ -2046,7 +2128,7 @@ void TVectorItem::translate ( TVector *v , SeqAA *aa , vector <Tdna2aa> &dna2aa 
       }
     }
 
-wxString TVectorItem::getAminoAcidSequence ()
+wxString TVectorItem::getAminoAcidSequence () // not const because of translate
     {
     wxString s ;
     vector <Tdna2aa> dna2aa ;
@@ -2055,7 +2137,7 @@ wxString TVectorItem::getAminoAcidSequence ()
     return s ;
     }    
 
-void TVectorItem::getArrangedAA ( TVector *v , wxString &s , int disp , SeqAA *aa )
+void TVectorItem::getArrangedAA ( TVector * const v , wxString &s , const int disp , SeqAA * const aa ) // not const
     {
     vector <Tdna2aa> dna2aa_temp , *dna2aa ;
     if ( v->getGenomeMode() ) dna2aa = &dna2aa_temp ;
@@ -2078,7 +2160,7 @@ void TVectorItem::getArrangedAA ( TVector *v , wxString &s , int disp , SeqAA *a
        }
     }
 
-int TVectorItem::getOffsetAt ( int i )
+int TVectorItem::getOffsetAt ( int i ) const
     {
 //    myass ( lastVector , "TVectorItem::getOffsetAt" ) ;
     if ( !lastVector ) return -1 ;
@@ -2092,7 +2174,7 @@ int TVectorItem::getOffsetAt ( int i )
     return -1 ;
     }
     
-int TVectorItem::getMem ()
+int TVectorItem::getMem () const
     {
     int a , r = 0 ;
     for ( a = 0 ; a < pname.GetCount() ; a++ ) r += pname[a].length() + pvalue[a].length() ;
@@ -2104,14 +2186,14 @@ int TVectorItem::getMem ()
     return r ;
     }    
     
-void TVectorItem::setLastVector ( TVector *v )
+void TVectorItem::setLastVector ( const TVector * const v )
     {
     lastVector = v ;
     }    
                 
 // ******************************************************************* Tdna2aa
 
-Tdna2aa::Tdna2aa ( char _aa , int i1 , int i2 , int i3 )
+Tdna2aa::Tdna2aa ( const char _aa , const int i1 , const int i2 , const int i3 )
     {
     aa = _aa ;
     dna[0] = i1 ;
@@ -2132,7 +2214,7 @@ TAAProp::TAAProp ()
     hl_mammal = hl_yeast = hl_ecoli = 0 ;
     }
     
-void TAAProp::set_cf ( int pa , int pb , int pt , float f0 , float f1 , float f2 , float f3 )
+void TAAProp::set_cf ( const int pa , const int pb , const int pt , const float f0 , const float f1 , const float f2 , const float f3 )
     {
     cf_pa = pa ;
     cf_pb = pb ;
@@ -2143,20 +2225,20 @@ void TAAProp::set_cf ( int pa , int pb , int pt , float f0 , float f1 , float f2
     cf_f[3] = f3 ;
     }
     
-void TAAProp::set_data ( float _mw , float _pi , wxString _tla )
+void TAAProp::set_data ( const float _mw , const float _pi , const wxString& _tla )
     {
     mw = _mw ;
     pi = _pi ;
     tla = _tla ;
     }
     
-void TAAProp::set_hp ( float _hp_kd , float _hp_hw )
+void TAAProp::set_hp ( const float _hp_kd , const float _hp_hw )
     {
     hp_kd = _hp_kd ;
     hp_hw = _hp_hw ;
     }
 
-void TAAProp::set_atoms ( int C , int H , int N , int O , int S )
+void TAAProp::set_atoms ( const int C , const int H , const int N , const int O , const int S )
 	{
 	carbon = C ;
 	hydrogen = H ;
@@ -2165,14 +2247,14 @@ void TAAProp::set_atoms ( int C , int H , int N , int O , int S )
 	sulfur = S ;
  	}
          
-void TAAProp::set_halflife ( int mammal , int yeast , int ecoli )
+void TAAProp::set_halflife ( const int mammal , const int yeast , const int ecoli )
 	{
 	hl_mammal = mammal ;
 	hl_yeast = yeast ;
 	hl_ecoli = ecoli ;
 	}
      
-wxString TAAProp::get_halflife_text ( int hl )
+wxString TAAProp::get_halflife_text ( int hl ) const
 	{
 	wxString ret ;
 	if ( hl == 0 ) return txt("t_hl_unknown") ;
@@ -2200,19 +2282,19 @@ TORF::TORF ()
  	} ;
 
 
-TORF::TORF ( int _f , int _t , int _r )
+TORF::TORF ( const int _f , const int _t , const int _r )
 	{
 	set ( _f , _t , _r ) ;
 	}
 
-void TORF::set ( int _f , int _t , int _r )
+void TORF::set ( const int _f , const int _t , const int _r )
 	{
 	from = _f ;
 	to = _t ;
 	rf = _r ;
 	} ;
 
-wxString TORF::getText ()
+wxString TORF::getText () const
 	{
 	return wxString::Format ( _T("%d-%d, %d") , from , to , rf ) ;
 	}    

--- a/TVector.h
+++ b/TVector.h
@@ -33,16 +33,16 @@ class TEnzymeRules ;
 
 /// This class manages amino acid properties; so 20 total. Used by the static part of TVector
 class TAAProp
-    {
-    public :
+{
+  public :
     TAAProp () ; ///< Constructor
     ~TAAProp () {} ; ///< Destructor (empty)
-    void set_cf ( int pa , int pb , int pt , float f0 , float f1 , float f2 , float f3 ) ; ///< Some data
-    void set_data ( float _mw , float _pi , wxString _tla ) ; ///< Molecular weight, isoelectric point, three-letter acronym
-    void set_hp ( float _hp_kd , float _hp_hw ) ; ///< More data
-    void set_atoms ( int C , int H , int N , int O , int S ) ; ///< Atoms in this amino acid
-    void set_halflife ( int mammal , int yeast , int ecoli ) ; ///< Half-life (not the game!)
-    wxString get_halflife_text ( int hl ) ; ///< Returns half-life estimation
+    void set_cf ( const int pa , const int pb , const int pt , const float f0 , const float f1 , const float f2 , const float f3 ) ; ///< Some data
+    void set_data ( const float _mw , const float _pi , const wxString& _tla ) ; ///< Molecular weight, isoelectric point, three-letter acronym
+    void set_hp ( const float _hp_kd , const float _hp_hw ) ; ///< More data
+    void set_atoms ( const int C , const int H , const int N , const int O , const int S ) ; ///< Atoms in this amino acid
+    void set_halflife ( const int mammal , const int yeast , const int ecoli ) ; ///< Half-life (not the game!)
+    wxString get_halflife_text ( const int hl ) const ; ///< Returns half-life estimation
     wxString tla ; ///< Three-letter acronym
     float mw , pi ;
     float cf_f[4] ; ///< Some data
@@ -51,84 +51,84 @@ class TAAProp
     int hl_mammal , hl_yeast , hl_ecoli ;
     float hp_kd , hp_hw ;
     vector <float> data ; ///< For temporary data only
-    } ;
+} ;
 
 /// This class manages open reading frames (ORFs)
 class TORF
-    {
-    public :
+{
+  public :
     TORF () ; ///< Default constructor, empty
-    TORF ( int _f , int _t , int _r ) ; ///< Constructor
-	~TORF () {} ; ///< Destructor (empty)
+    TORF ( const int _f , const int _t , const int _r ) ; ///< Constructor
+    ~TORF () {} ; ///< Destructor (empty)
     
-    wxString getText () ;
-    void set ( int _f , int _t , int _r ) ;
-    inline int get_from () { return from ; }
-	inline int get_to () { return to ; }
-	inline int get_rf () { return rf ; }
+    wxString getText () const ;
+    void set ( const int _f , const int _t , const int _r ) ;
+    inline int get_from () const { return from ; }
+    inline int get_to () const { return to ; }
+    inline int get_rf () const { return rf ; }
 
     float dist1 , dist2 ;
     float deg1 , deg2 ;
     
-    private:
+  private:
     /// \brief Start of ORF
     int from , to ; ///< End of ORF
     int rf ; ///< Reading frame
     
-    } ;
+} ;
 
 /// This class stores a codon and the corresponding amino acid. Used by TVector
 class Tdna2aa
     {
     public :
     Tdna2aa () {} ; ///< Default constructor, empty
-    Tdna2aa ( char _aa , int i1 , int i2 , int i3 ) ; ///< Constructor
+    Tdna2aa ( const char _aa , const int i1 , const int i2 , const int i3 ) ; ///< Constructor
     char aa ; ///< Single-letter AA code
     int dna[3] ; ///< The three DNA positions that make up the codon
     } ;
 
 /// This class stores a vector item.
 class TVectorItem
-    {
-    public :
+{
+ public :
     TVectorItem () ; ///< Default constructor
-    TVectorItem ( wxString sn , wxString n , int f , int t , char ty ) ; ///< Constructor
-	~TVectorItem () {} ; ///< Destructor (empty)
+    TVectorItem ( const wxString& sn , const wxString& n , const int f , const int t , const char ty ) ; ///< Constructor
+    ~TVectorItem () {} ; ///< Destructor (empty)
     
-    wxBrush *getBrush () ; ///< Returns a pointer to the brush used to draw the item
-    wxColour getFontColor () ; ///< Returns the font color
-    void setColor ( wxColour col ) ; ///< Sets the font color
-    bool isVisible () ; ///< Is this item visible?
-    void setVisible ( bool b ) ; ///< Set visibility
-    int getRF () ; ///< Returns the reading frame
-    void setRF ( int x ) ; ///< Sets the reading frame
-    int getOffset () ; ///< returns the offset; -1 = no offset
-    void setOffset ( int o = -1 ) ; ///< Sets the offset; -1 = no offset
-    void setType ( wxString s ) ; ///< Sets the item type
-    int getOffsetAt ( int i ) ; ///< Returns the offset of the item at a specific position
+    wxBrush *getBrush () const ; ///< Returns a pointer to the brush used to draw the item
+    wxColour getFontColor () const ; ///< Returns the font color
+    void setColor ( const wxColour& col ) ; ///< Sets the font color
+    bool isVisible () const ; ///< Is this item visible?
+    void setVisible ( const bool b ) ; ///< Set visibility
+    int getRF () const ; ///< Returns the reading frame
+    void setRF ( const int x ) ; ///< Sets the reading frame
+    int getOffset () const ; ///< returns the offset; -1 = no offset
+    void setOffset ( const int o = -1 ) ; ///< Sets the offset; -1 = no offset
+    void setType ( const wxString& s ) ; ///< Sets the item type
+    int getOffsetAt ( const int i ) const; ///< Returns the offset of the item at a specific position
     
-    void doRemove ( int f , int t , int l ) ; ///< Remove a part of the item
+    void doRemove ( const int f , const int t , const int l ) ; ///< Remove a part of the item
     wxString implodeParams () ; ///< Join item parameters for storage
-    void explodeParams ( wxString _s ) ; ///< Extract item parameters from stored form
+    void explodeParams ( const wxString& _s ) ; ///< Extract item parameters from stored form
     wxTreeItemId getTreeID () { return treeid ; } ; ///< The current ID of the item in TVectorTree
     void setTreeID ( wxTreeItemId newid ) { treeid = newid ; } ///< Set new item ID in TVectorTree
     int getDirection () { return direction ; } ///< Return the direction
     void setDirection ( int newdir ) { direction = newdir ; } ///< Set the direction
     char getType () { return type ; } ///< Returns the item type
     void setType ( char newtype ) { type = newtype ; } ///< Sets the item type
-    int getMem () ; ///< Estimates the memory usage of this item (debugging use only)
+    int getMem () const ; ///< Estimates the memory usage of this item (debugging use only)
 
     // Parameters
-    wxString getParam ( wxString p , wxString def = _T("") ) ; ///< Returns the value of a parameter; optional default value
-    wxArrayString getParamKeys () ; ///< Get a list of all parameter keys
-    void setParam ( wxString p , wxString v ) ; ///< Set a parameter key/value pair
-    void setParam ( wxString p , int v ) ; ///< Set a parameter key/value pair
+    const wxString getParam ( const wxString& p , const wxString& def = _T("") ) const ; ///< Returns the value of a parameter; optional default value
+    wxArrayString getParamKeys () const ; ///< Get a list of all parameter keys
+    void setParam ( const wxString& p , const wxString& v ) ; ///< Set a parameter key/value pair
+    void setParam ( const wxString& p , const int v ) ; ///< Set a parameter key/value pair
 
     // dna2aa stuff
-    void translate ( TVector *v , SeqAA *aa , vector <Tdna2aa> &dna2aa ) ; ///< Translate DNA to amino acids
-    void getArrangedAA ( TVector *v , wxString &s , int disp , SeqAA *aa = NULL ) ; ///< Generate the amino acid sequence in place
+    void translate ( const TVector * const v , SeqAA * const aa , vector <Tdna2aa> &dna2aa ) ; ///< Translate DNA to amino acids
+    void getArrangedAA ( TVector * const v , wxString &s , const int disp , SeqAA *aa = NULL ) ; ///< Generate the amino acid sequence in place, not const
     wxString getAminoAcidSequence () ; ///< Return the amino acid sequence
-    void setLastVector ( TVector *v ) ; ///< Set the last TVector to own this item
+    void setLastVector ( const TVector * const v) ; ///< Set the last TVector to own this item
     
     // Variables
     /// \brief Item description
@@ -137,7 +137,7 @@ class TVectorItem
     int from , ///< Item start
     	to ; ///< Item end
     
-    private:
+  private:
     void initParams () ; ///< Reset parameters
     
     signed char direction ; ///< The item direction; 1=clockwise, -1=counter-clockwise
@@ -147,7 +147,7 @@ class TVectorItem
     /// \brief Parameter keys
     wxArrayString pname , pvalue ; ///< Parameter values
     vector <Tdna2aa> dna2aa_item ; ///< The cache of the translated amino acids
-    TVector *lastVector ; ///< The last TVector to own this item
+    const TVector *lastVector ; ///< The last TVector to own this item
 
     // Visual information
     friend class TVectorEditor ;
@@ -157,7 +157,7 @@ class TVectorItem
     int r1 , r2 ;
     int r3 , r4 ; // Only used in linar display mode
     float a1 , a2 ;
-    } ;
+} ;
 
 /** \brief This class stores all sequence information, both DNA and amino acids
 
@@ -167,9 +167,12 @@ class TVectorItem
 	does much more than storing vectors.
 */
 class TVector
-    {
-    public :
+{
+  public :
     TVector ( ChildBase *win = NULL ) ; ///< Constructor
+    //TVector ( const TVector& original) ; 
+    //TVector& operator=(const TVector& other); // Assignment operator
+    
     ~TVector () ; ///< Destructor
     void init () ; ///< Set up basic values
     void clear () ; ///< Reset internal state
@@ -181,131 +184,131 @@ class TVector
     bool reduceToFragment ( TRestrictionCut left , TRestrictionCut right ) ; ///< Cuts off everything except what is betreen these two cuts
     void doRestriction () ; ///< Performs restriction. See TRestrictionEditor
     void sortRestrictionSites () ; ///< Sorts the restriction sites by point of cut
-    int countCuts ( wxString enzyme ) ; ///< Counts the number of cuts for an enzyme in this sequence
+    int countCuts ( const wxString& enzyme ) const ; ///< Counts the number of cuts for an enzyme in this sequence
     void methylationSites ( wxArrayInt &vi , int what = ALL_METHYLATION_ENZYMES ) ; ///< Finds methylation sites
     
     // Nucleotide access/conversion
-    bool basematch ( char b1 , char b2 ) ; ///< matches DNA bases; b1 in IUPAC, b2 in SIUPAC. This is superior to the "=" operator :-)
+    bool basematch ( const char b1 , const char b2 ) const ; ///< matches DNA bases; b1 in IUPAC, b2 in SIUPAC. This is superior to the "=" operator :-)
     void setIUPAC ( char b , wxString s , char *pac = NULL ) ;
-    char getNucleotide ( int pos , bool complement = false ) ; ///< Returns the base at a certain position, or its complement
-    void setNucleotide ( int pos , char t ) ; ///< Sets a base at a certain position
-    char getComplement ( char c ) ; ///< Returns the complement of a given base
+    char getNucleotide ( const int pos , const bool complement = false ) const ; ///< Returns the base at a certain position, or its complement
+    void setNucleotide ( const int pos , const char t ) ; ///< Sets a base at a certain position
+    char getComplement ( const char c ) const ; ///< Returns the complement of a given base
     
     // Vector/sequence access
-    void ligate_right ( TVector &v , bool inverted = false ) ; ///< Adds another TVector to the right of this one
+    void ligate_right ( TVector &v , const bool inverted = false ) ; ///< Adds another TVector to the right of this one
     void closeCircle () ; ///< Closes a linear sequence into a circular (intramolecular ligation)
-    void turn ( int off ) ; ///< Turns a circular sequence "off" bases
+    void turn ( const int off ) ; ///< Turns a circular sequence "off" bases
     
-    TVector *getAAvector ( int from , int to , int dir = 1 ) ; ///< Returns part of the sequence translated into amino acids
+    TVector *getAAvector ( const int from , const int to , const int dir = 1 ) const ; ///< Returns part of the sequence translated into amino acids
     void doAction () ; ///< Perform an action (restriction, usually). Internal use
-    void doRemove ( int from , int to , bool update = true , bool enableUndo = true ) ; ///< Removes part of the sequence
-    void insert_char ( char x , int pos , bool overwrite = false ) ; ///< Inserts a character into the sequence
+    void doRemove ( const int from , const int to , const bool update = true , const bool enableUndo = true ) ; ///< Removes part of the sequence
+    void insert_char ( const char x , const int pos , const bool overwrite = false ) ; ///< Inserts a character into the sequence
     
-    float getAAmw ( char aa ) ; ///< Returns the molecular weight of an amino acid
-    float getAApi ( char aa ) ; ///< Returns the isoelectric point of an amino acid
-    wxString dna2aa ( wxString codon , int translation_table = -1 ) ; ///< Translates a codon into an amino acid
-    void setAction ( wxString _action , int _action_value = 0 ) ; ///< Sets the action for doAction()
-    void setDatabase ( wxString s ) { database = s ; } ///< Sets the database in which the sequence is stored
-    wxString getDatabase () { return database ; } ///< Returns the database name in which the sequence is stored
-    TVector *newFromMark ( int from , int to ) ; ///< Generates a new sequence based on a part of this one
+    float getAAmw ( const char aa ) const ; ///< Returns the molecular weight of an amino acid
+    float getAApi ( const char aa ) const ; ///< Returns the isoelectric point of an amino acid
+    wxString dna2aa ( const wxString& codon , const int translation_table = -1 ) const ; ///< Translates a codon into an amino acid
+    void setAction ( const wxString& _action , int _action_value = 0 ) ; ///< Sets the action for doAction()
+    void setDatabase ( const wxString& s ) { database = s ; } ///< Sets the database in which the sequence is stored
+    const wxString getDatabase () const { return database ; } ///< Returns the database name in which the sequence is stored
+    TVector *newFromMark ( const int from , const int to ) const ; ///< Generates a new sequence based on a part of this one
     
-    void setChanged ( bool c = true ) ; ///< The sequence has been changed.
-    bool isChanged () { return changed ; } ///< Was the sequence changed?
+    void setChanged ( const bool c = true ) ; ///< The sequence has been changed.
+    bool isChanged () const { return changed ; } ///< Was the sequence changed?
     
     void ClearORFs () ; ///< Clear the found open reading frames
-    void addORFs ( int off ) ; ///< Add open reading frames for a specific reading frame
+    void addORFs ( const int off ) ; ///< Add open reading frames for a specific reading frame
 
     void removeBlanksFromSequence () ; ///< Removes blank chars (spaces etc.) from the sequence
     void removeBlanksFromVector () ; ///< Removes blank chars (spaces etc.) from the sequence, altering items if necessary
     
-    wxString getParams () ; ///< Return sequence parameters
-    void setParams ( wxString t ) ; ///< Set sequence parameters
-    wxString getParam ( wxString key ) ; ///< Return the value of a parameter
-    void setParam ( wxString key , wxString value ) ; ///< Set a parameter key/value pair
-    void setWindow ( ChildBase *c ) ; ///< Set the window which owns this sequence
-    void setCircular ( bool c = true ) ; ///< This is a circular sequence (or linear, if c == false)
-    bool isCircular () ; ///< Is this a circular sequence?
-    bool isLinear () ; ///< Is this a linear sequence?
-    wxString one2three ( int a ) ; ///< Converts one letter amino acid code to three-letter acronym
-    char three2one ( wxString s ) ; ///< Converts three-letter acronym to one letter amino acid code
-    void setStickyEnd ( bool left , bool upper , wxString s ) ; ///< Sets one of the four possible sticky ends
+    wxString getParams () const ; ///< Return sequence parameters
+    void setParams ( const wxString& t ) ; ///< Set sequence parameters
+    const wxString getParam ( const wxString& key ) const ; ///< Return the value of a parameter
+    void setParam ( const wxString& key , const wxString& value ) ; ///< Set a parameter key/value pair
+    void setWindow ( ChildBase * const c ) ; ///< Set the window which owns this sequence
+    void setCircular ( const bool c = true ) ; ///< This is a circular sequence (or linear, if c == false)
+    bool isCircular () const ; ///< Is this a circular sequence?
+    bool isLinear () const ; ///< Is this a linear sequence?
+    const wxString one2three ( const int a ) const ; ///< Converts one letter amino acid code to three-letter acronym
+    char three2one ( wxString s ) const ; ///< Converts three-letter acronym to one letter amino acid code
+    void setStickyEnd ( const bool left , const bool upper , const wxString& s ) ; ///< Sets one of the four possible sticky ends
     wxString getStickyEnd ( bool left , bool upper ) ; ///< Returns one of the possible sticky ends
-    bool hasStickyEnds () ; ///< Does this sequence have sticky ends?
+    bool hasStickyEnds () const ; ///< Does this sequence have sticky ends?
     void callUpdateUndoMenu () ; ///< Refreshes the Undo menu
-    void setFromVector ( TVector &v ) ; ///< Makes this sequence a copy of another one (v)
+    void setFromVector ( const TVector &v ) ; ///< Makes this sequence a copy of another one (v)
     void doRemoveNucleotide ( int x ) ; ///<Removes single base at position x
     int getItemLength ( int a ) ; ///< Return the length of item a
-    TVector *backtranslate ( wxString mode = _T("") ) ; ///< Generate a new DNA sequence from this amino acid sequence
-    wxString getStrand53 () ; ///< Returns the 5'->3' strand of the sequence
-    wxString getStrand35 () ; ///< Returns the 3'->5' strand of the sequence, as 5'->3'
+    TVector *backtranslate ( const wxString& mode = _T("") ) ; ///< Generate a new DNA sequence from this amino acid sequence
+    wxString getStrand53 () const ; ///< Returns the 5'->3' strand of the sequence
+    wxString getStrand35 () const ; ///< Returns the 3'->5' strand of the sequence, as 5'->3'
 
-    TAAProp getAAprop ( char a ) ; ///< Returns the properties of the one-letter code amino acid
-    int find_item ( wxString s ) ; ///< Finds an item with that name
-    bool isEnzymeHidden ( wxString s ) ; ///< Is enzyme "s" hidden?
-    void hideEnzyme ( wxString s , bool hideit = true ) ; ///< Set enzyme hidden state
+    TAAProp getAAprop ( const char a ) const ; ///< Returns the properties of the one-letter code amino acid
+    int find_item ( const wxString& s ) const ; ///< Finds an item with that name
+    bool isEnzymeHidden ( const wxString&s ) const ; ///< Is enzyme "s" hidden?
+    void hideEnzyme ( const wxString& s , bool hideit = true ) ; ///< Set enzyme hidden state
 
-    wxString getSubstring ( int mf , int mt ) ; ///< Returns a sequence substring
-    wxString transformSequence ( bool inverse , bool reverse ) ; ///< Transforms the sequence
-    wxString getSequence () ; ///< Returns the sequence
+    wxString getSubstring ( const int mf , const int mt ) ; ///< Returns a sequence substring
+    wxString transformSequence ( const bool inverse , const bool reverse ) const ; ///< Transforms the sequence
+    wxString getSequence () const ; ///< Returns the sequence
     wxString *getSequencePointer () ; ///< Internal use; only used by SequenceCanvas::OnCharHook
-    char getSequenceChar ( int x ) ; ///< Gets base at position x
-    void setSequence ( wxString ns ) ; ///< Sets the sequence
-    void addToSequence ( wxString x ) ; ///< Appends to the sequence
-    void alterSequence ( int pos , char c ) ; ///< Changes the base at position pos into c
-    int getSequenceLength() ; ///< Returns the sequence length
-    void eraseSequence ( int from , int len ) ; ///< Removes part of the sequence
-    void removeAlignmentArtifacts ( char what = '-' ) ; ///< Removes alignment artifacts from the sequence
+    char getSequenceChar ( const int x ) const; ///< Gets base at position x
+    void setSequence ( const wxString& ns ) ; ///< Sets the sequence
+    void addToSequence ( const wxString& x ) ; ///< Appends to the sequence
+    void alterSequence ( const int pos , const char c ) ; ///< Changes the base at position pos into c
+    int getSequenceLength() const ; ///< Returns the sequence length
+    void eraseSequence ( const int from , const int len ) ; ///< Removes part of the sequence
+    void removeAlignmentArtifacts ( const char what = '-' ) ; ///< Removes alignment artifacts from the sequence
     
-    wxString getDescription () ; ///< Returns the sequence description
-    void setDescription ( wxString s ) ; ///< Sets the sequence description
-    void addDescription ( wxString s ) ; ///< Appends to the sequence description
-    wxString getName () ; ///< Returns the sequence name
-    void setName ( wxString s ) ; ///< Sets the sequence name
-    void addName ( wxString s ) ; ///< Appends to the sequence name
+    const wxString getDescription () const ; ///< Returns the sequence description
+    void setDescription ( const wxString& s ) ; ///< Sets the sequence description
+    void addDescription ( const wxString& s ) ; ///< Appends to the sequence description
+    const wxString getName () const ; ///< Returns the sequence name
+    void setName ( const wxString& s ) ; ///< Sets the sequence name
+    void addName ( const wxString& s ) ; ///< Appends to the sequence name
     void setGenomeMode ( bool gm = true ) ; ///< Turns genome mode on/off
-    bool getGenomeMode () ; ///< Returns the genome mode
-    int getMem () ; ///< Returns memory usage estimate for this sequence. Debugging use only
+    bool getGenomeMode () const ; ///< Returns the genome mode
+    int getMem () const ; ///< Returns memory usage estimate for this sequence. Debugging use only
     bool getVectorCuts ( TVector *v ) ; ///< Returns wether or not isoenzymes should be joined
-    TEnzymeRules *getEnzymeRule () ; ///< Gets the enzyme rules to follow
-    int showGC () ; ///< Returns 0 for "no", otherwise the number of blocks
-    TORF *getORF ( int a ) ; ///< Returns an open reading frame
+    TEnzymeRules *getEnzymeRule () const ; ///< Gets the enzyme rules to follow
+    int showGC () const ; ///< Returns 0 for "no", otherwise the number of blocks
+    TORF *getORF ( const int a ) ; ///< Returns an open reading frame
     int countORFs () ; ///< Returns the number of found open reading frames
     void updateDisplay ( bool update = true ) ; ///< Recalc visual information on next draw
     bool displayUpdate () ; ///< Update the display?
-    void setType ( int newtype ) ; ///< Set the sequence type
-    int getType () ; ///< Returns the sequence type
-    int getMethylationSiteIndex ( int pos ) ; ///< Returns the index of a potential methylation site
-    int getMethylationSite ( int index ) ; ///< Returns the position of a methylation site
-    int countMethylationSites () ; ///< Returns the number of found methylation sites
-    void prepareFeatureEdit ( int pos , bool overwrite ) ; ///< Changes feature names or cuts features that are about to be edited
-    TEnzymeRules *getEnzymeRules () ; ///< Returns the restriction enzyme display rules for this vector
+    void setType ( const int newtype ) ; ///< Set the sequence type
+    int getType () const ; ///< Returns the sequence type
+    int getMethylationSiteIndex ( const int pos ) const ; ///< Returns the index of a potential methylation site
+    int getMethylationSite ( const int index ) const ; ///< Returns the position of a methylation site
+    int countMethylationSites () const ; ///< Returns the number of found methylation sites
+    void prepareFeatureEdit ( const int pos , const bool overwrite ) ; ///< Changes feature names or cuts features that are about to be edited
+    TEnzymeRules *getEnzymeRules () const ; ///< Returns the restriction enzyme display rules for this vector
     void setEnzymeRules ( TEnzymeRules *er ) ; ///< Sets the restriction enzyme display rules for this vector
-    void getItemsAtPosition ( int pos , wxArrayInt &vi , bool limit = false ) ; ///< Retrieves a list of items at that position (pos is 0-based)
-    bool hasItemsAtPosition ( int pos ) ; ///< Returns wether there are items at that position (pos is 0-based)
-    int countCodonTables () ;
-    wxString getCodonTableName ( int x ) ;
-    void addRestrictionEnzyme ( TRestrictionEnzyme *e ) ;
+    void getItemsAtPosition ( const int pos , wxArrayInt &vi , const bool limit = false ) const ; ///< Retrieves a list of items at that position (pos is 0-based)
+    bool hasItemsAtPosition ( const int pos ) const ; ///< Returns wether there are items at that position (pos is 0-based)
+    int countCodonTables () const ;
+    wxString getCodonTableName ( const int x ) const ;
+    void addRestrictionEnzyme ( TRestrictionEnzyme * const e ) ;
     void resetTurn () ; ///< Sets the turned variable to zero
 	
     // Variables
     vector <TVectorItem> items ; ///< Items/features/annotations
     vector <TRestrictionCut> rc ; ///< Restriction enzyme cuts
     
-    wxArrayTRestrictionEnzyme re , ///< Manually specified restriction enzymes
-    						  re2 ; ///< Automatically added restriction enzymes
+    wxArrayTRestrictionEnzyme re ,  ///< Manually specified restriction enzymes
+                              re2 ; ///< Automatically added restriction enzymes
 
-    wxArrayString proteases ,  ///< Proteases used
-     	cocktail ; ///< Enzymes from the last restriction
+    wxArrayString proteases , ///< Proteases used
+                  cocktail ;  ///< Enzymes from the last restriction
     TUndo undo ; ///< Undo information
     
-    private :
-    wxString invert ( wxString s ) ; ///< Inverts a string
-    wxString vary_base ( char b ) ; ///< Turns a SIUPAC into a string of A, C, G, T
-    void makeAA2DNA ( wxString mode = _T("") ) ; ///< "Translate" amino acid sequence into DNA; can be specified for an organism
+  private :
+    wxString invert ( const wxString& s ) const ; ///< Inverts a string
+    wxString vary_base ( const char b ) const ; ///< Turns a SIUPAC into a string of A, C, G, T
+    void makeAA2DNA ( const wxString& mode = _T("") ) ; ///< "Translate" amino acid sequence into DNA; can be specified for an organism
     wxString mergeCodons ( wxString c1 , wxString c2 ) ; ///< Used by makeAA2DNA for generating "abstract" (SIUPAC) DNA
-    void setCodonTable ( int table , wxString sequence , wxString name ) ; ///< Sets up the codon_tables variable
-    void evaluate_key_value ( wxString key , wxString value ) ; ///< Used in setParam() and setParams()
-    wxString get_translation_table ( int translation_table ) ;
+    void setCodonTable ( const int table , const wxString& sequence , const wxString& name ) ; ///< Sets up the codon_tables variable
+    void evaluate_key_value ( const wxString& key , const wxString& value ) ; ///< Used in setParam() and setParams()
+    wxString get_translation_table ( const int translation_table ) const ;
 
     int type ; ///< The sequence type
     TEnzymeRules *enzyme_rules ; ///< Pointer to the restriction enzyme display rules
@@ -332,7 +335,7 @@ class TVector
     wxString AA2DNA[256] ; ///< AA-to-DNA "translation" table; used by makeAA2DNA()
     wxArrayString paramk ; ///< Parameter keys
     wxArrayString paramv ; ///< Parameter values
-    
+
     static char IUPAC[256] ; ///< The ACTG chars in binary encoding (IUPAC_A, IUPAC_C, IUPAC_T, IUPAC_G)
     static char SIUPAC[256] ; ///< The extended IUPAC codes in binary encoding
     static char COMPLEMENT[256] ; ///< The complement to each SIUPAC base
@@ -340,7 +343,9 @@ class TVector
     static vector <TAAProp> aaprop ; ///< The 20 amino acids and their properties
     static wxArrayString codon_tables ; ///< The codon tables for different organisms
     static wxArrayString codon_table_names ; ///< The names of these codon tables
+
+    friend class TVector;
+
     } ;
     
 #endif
-

--- a/TVirtualGel.cpp
+++ b/TVirtualGel.cpp
@@ -249,7 +249,7 @@ void TMyGelControl::OnDraw(wxDC& dc)
 
     int tw , th ;
     wxString title = _T("t_gelname_") + vg->type ;
-    title = wxString::Format ( txt(title.c_str()) , vg->percent ) ;
+    title = wxString::Format ( txt(title) , vg->percent ) ;
     dc.SetTextForeground ( *wxBLACK ) ;
     dc.SetFont ( *bigFont ) ;
     dc.GetTextExtent ( title , &tw , &th ) ;
@@ -415,7 +415,7 @@ void TMyGelControl::OnSaveAsBitmap(wxCommandEvent &event)
     dc.Clear() ;
 	OnDraw ( dc ) ;
     wxString title = _T("t_gelname_") + vg->type ;
-    title = wxString::Format ( txt(title.c_str()) , vg->percent ) ;
+    title = wxString::Format ( txt(title) , vg->percent ) ;
     myapp()->frame->saveImage ( &bmp , title ) ;
     }
     

--- a/TVirtualGel.cpp
+++ b/TVirtualGel.cpp
@@ -152,7 +152,7 @@ void TVirtualGel::initme ()
     Activate () ;
 	}
 
-wxString TVirtualGel::getName ()
+const wxString TVirtualGel::getName () const
     {
     return _T("Virtual Gel") ;
     }

--- a/TVirtualGel.h
+++ b/TVirtualGel.h
@@ -34,12 +34,12 @@ class TGelLane
 	\brief The virtual gel module
 */
 class TVirtualGel : public ChildBase
-    {
-    public :
+{
+  public :
     TVirtualGel(wxWindow *parent, const wxString& title) ; ///< Constructor
     
     virtual void initme () ; ///< Initialization
-    virtual wxString getName () ; ///< Returns the gel module name
+    virtual const wxString getName () const ; ///< Returns the gel module name
 
     virtual void OnPercent ( wxCommandEvent &ev ) ; ///< Gel percent setting change event handler
     virtual void OnLabel ( wxCommandEvent &ev ) ; ///< Show labels event handler
@@ -55,7 +55,7 @@ class TVirtualGel : public ChildBase
     int cutoff , maxband ;
     
     DECLARE_EVENT_TABLE()
-    } ;
+} ;
     
 /**	\class TMyGelControl
 	\brief This class handles a single virtual gel for TVirtualGel, using TGelLane lanes
@@ -94,7 +94,7 @@ class TRestrictionIdentifier : public TVirtualGel
     
     virtual void OnDNAListChange(wxCommandEvent &event);
     virtual void OnEnzymeListChange(wxCommandEvent &event);
-    virtual wxString getName () ; ///< Returns the gel module name
+    virtual const wxString getName () const ; ///< Returns the gel module name
     virtual void otherChildrenChanged () ;
 
     private:

--- a/main.cpp
+++ b/main.cpp
@@ -106,12 +106,12 @@ wxString implode ( wxString sep , wxArrayString &r )
 	return ret ;
 	}
 
-wxString txt ( char *item )
+const wxString txt ( const char * const item )
 	{
 	return txt ( wxString(item,wxConvUTF8) ) ;
 	}
 
-wxString txt ( wxString item )
+const wxString txt ( wxString item )
     {
 #ifndef __WXMSW__
 	 if ( item.MakeUpper().Left(2) == _T("M_") )
@@ -129,7 +129,7 @@ wxString txt ( wxString item )
 // END GLOBAL FUNCTIONS
 
 
-void MyApp::registerFileExtension ( wxString extension )
+void MyApp::registerFileExtension ( const wxString& extension )
     {
 #ifdef __WXMSW__    
     wxRegKey regKey;
@@ -155,7 +155,7 @@ void MyApp::registerFileExtension ( wxString extension )
 #endif
     }
     
-void MyApp::registerProtocol ( wxString extension )
+void MyApp::registerProtocol ( const wxString& extension )
     {
 #ifdef __WXMSW__    
     wxRegKey regKey;

--- a/main.h
+++ b/main.h
@@ -202,8 +202,8 @@ class MyApp : public wxApp
 		wxStopWatch sw ;
     
     private :
-    virtual void registerFileExtension ( wxString extension ) ; ///< Registers a file extension to GENtle (windows only).
-    virtual void registerProtocol ( wxString extension ) ; ///< Registers a protocol to GENtle (windows only).
+    virtual void registerFileExtension ( const wxString& extension ) ; ///< Registers a file extension to GENtle (windows only).
+    virtual void registerProtocol ( const wxString& extension ) ; ///< Registers a protocol to GENtle (windows only).
     wxFile *errout ; ///< The ERROR.txt file handler for do_my_ass
     wxFile *logout ; ///< The LOG.txt file handler for do_my_log
     int total_log_time ; ///< The log timer for do_my_log
@@ -331,16 +331,16 @@ void explode ( wxString sep , wxString s , wxArrayString &r ) ;
 wxString implode ( wxString sep , wxArrayString &r ) ;
 /*
 //  \brief Returns the current language version of the "item" /
-char* txt ( wxString item ) ;
+const char * txt ( const wxString item ) ;
 
 //  \brief Returns the current language version of the "item" /
-char* txt ( char *item ) ;
+const char* txt ( const char * const item ) ;
 */
 /** \brief Returns the current language version of the "item" */
-wxString txt ( wxString item ) ;
+const wxString txt ( const wxString item ) ;
 
 /** \brief Returns the current language version of the "item" */
-wxString txt ( char *item ) ;
+const wxString txt ( const char * const item ) ;
 
 /** \brief Returns a pointer to the application */
 MyApp *myapp () ;


### PR DESCRIPTION
This may be too much to be added without a more rigorous testing - have introduced a "const" in particular for TVector when I had felt that a parameter is not meant to be changed by the respective function. The extra const gives extra confidence to pass parameters by reference, which may be more efficient for larger constructs, and it helps with the understanding of the function when skimming through the source code.