### PR TITLE
Fixing compiler error for C code because of C++ standard settings.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ else
     AC_MSG_ERROR([wxWidgets is required. Try --with-wx-config.])
 fi
 
-WX_CPPFLAGS="-std=gnu++11 `$WXCONFIG --cppflags`"
+WX_CPPFLAGS="`$WXCONFIG --cppflags`"
 WX_CXXFLAGS="-std=gnu++11 `$WXCONFIG --cxxflags | sed -e 's/-fno-exceptions//'`"
 WX_LIBS="`$WXCONFIG --libs`"
 


### PR DESCRIPTION
The error message was:
error: invalid argument '-std=gnu++11' not allowed with 'C'