### PR TITLE
Transition NCBI+Blast to https (smoe:fix_https_query)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,22 +7,28 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+#        os: [macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: installing non-GUI dependencies
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install default-libmysqlclient-dev libsqlite3-dev libtinyxml-dev autoconf automake make
-          autoconf --version
-      - name: installing wxWidgets
-        run: |
-          sudo apt install libwxgtk3.2-dev \
-          || sudo apt install libwxgtk3.0-gtk3-dev \
-          || sudo apt install libwxgtk3.0-dev
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew update
+            brew install wxwidgets m4 tinyxml zstd autoconf libtool automake wxwidgets libpng sqlite
+            brew install dylibbundler
+          elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo apt-get update
+            sudo apt install libwxgtk3.2-dev || sudo apt install wx3.2-headers || sudo apt install libwxgtk3.0-gtk3-dev || sudo apt install libwxgtk3.0-dev
+          fi
       - name: remove local redundancy to build-deps
         run: rm -f mysql* sqlite* && rm -rf clustalw tinyxml
       - name: autogen

--- a/ExternalBLAST.cpp
+++ b/ExternalBLAST.cpp
@@ -53,7 +53,7 @@ void EIpanel::init_blast()
     #error "This requires thread support!"
 #endif // wxUSE_THREADS
 
-/**    \brief A wxThreadHelper class to run BLAST queries in the background
+/** \brief A wxThreadHelper class to run BLAST queries in the background
 */
 class blastThread : public wxThreadHelper
 {
@@ -65,7 +65,7 @@ public :
         seq.Replace ( _T("|") , _T("") ) ; // Amino acid search fix
 
         // Put
-        url = _T("http://www.ncbi.nlm.nih.gov/blast/Blast.cgi?") ;
+        url = _T("https://www.ncbi.nlm.nih.gov/blast/Blast.cgi?") ;
         url += _T("CMD=Put") ;
         url += _T("&QUERY=") + seq ;
         url += _T("&DATABASE=nr") ;
@@ -73,7 +73,7 @@ public :
         if ( p->c1->GetSelection() == 1 ) url += _T("&PROGRAM=blastn") ;
         url += _T("&HITLIST_SIZE=") + p->c2->GetStringSelection() ;
 
-        res = ex.getText ( url ) ;
+        res = p->ExecuteHttpsQuery ( url ) ;
 
         hs = parseQblast ( res ) ;
         RID = hs[_T("RID")] ;
@@ -81,7 +81,7 @@ public :
 
         // Prepare URL
         RTOE.ToLong ( &wait ) ;
-        url = _T("http://www.ncbi.nlm.nih.gov/blast/Blast.cgi?") ;
+        url = _T("https://www.ncbi.nlm.nih.gov/blast/Blast.cgi?") ;
         url += _T("CMD=Get") ;
         url += _T("&RID=") + RID ;
         url += _T("&FORMAT_TYPE=XML") ;
@@ -109,7 +109,7 @@ public :
             }
 //          cout << res << endl << "----\n\n" ;
             wxMutexGuiEnter() ;
-            res = ex.getText ( url ) ;
+            res = p->ExecuteHttpsQuery ( url ) ;
             wxMutexGuiLeave() ;
 
             hs = parseQblast ( res ) ;
@@ -310,9 +310,17 @@ void EIpanel::process_blast2()
     mylog ( "blast2" , "8" ) ;
     }
 
-wxString EIpanel::blast_align ( wxString qseq , wxString mseq , wxString hseq , int cpl , int qoff , int hoff )
+wxString EIpanel::blast_align ( const wxString& _qseq , const wxString& _mseq , const wxString& _hseq , const int _cpl , const int _qoff , const int _hoff )
     {
     wxString lead[3] ;
+    wxString mseq = _mseq ;
+    wxString hseq = _hseq ;
+    wxString qseq = _qseq ;
+
+    int hoff ( _hoff ) ;
+    int qoff ( _qoff ) ;
+    int cpl ( _cpl ) ;
+
     lead[0] = txt("t_blast_qseq" ) ;
     lead[2] = txt("t_blast_hseq" ) ;
     while ( lead[0].Length() < lead[2].Length() ) lead[0] += _T(" ") ;
@@ -336,8 +344,8 @@ wxString EIpanel::blast_align ( wxString qseq , wxString mseq , wxString hseq , 
     while ( !qseq.IsEmpty() )
         {
 //      ret += "<p>" ;
-	int a ;
         wxString z ;
+        int a ;
         for ( a = 0 , z = qseq.Left ( cpl ) ; a < z.length() ; a++ ) if ( z.GetChar(a) >= 'A' && z.GetChar(a) <= 'Z' ) qoff++ ;
         for ( a = 0 , z = hseq.Left ( cpl ) ; a < z.length() ; a++ ) if ( z.GetChar(a) >= 'A' && z.GetChar(a) <= 'Z' ) hoff++ ;
 
@@ -371,7 +379,7 @@ void EIpanel::execute_blast_b3()
         if ( a == -1 ) return ;
         s = s.Mid ( a + 3 ) ;
         s = s.BeforeFirst ( '|' ) ;
-        s = _T("http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?cmd=Retrieve&db=") + database + _T("&list_uids=") + s + _T("&dopt=GenPept") ;
+        s = _T("https://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?cmd=Retrieve&db=") + database + _T("&list_uids=") + s + _T("&dopt=GenPept") ;
         s = myapp()->getHTMLCommand ( s ) ;
         wxExecute ( s ) ;
         }

--- a/ExternalInterface.cpp
+++ b/ExternalInterface.cpp
@@ -126,7 +126,7 @@ EILB::EILB ( wxWindow *parent , int id ) : wxHtmlListBox ( parent , id , wxDefau
     SetItemCount ( 0 ) ;
     }
 
-wxString EILB::OnGetItem(size_t n) const
+wxString EILB::OnGetItem(const size_t n) const
     {
     if ( n >= was.GetCount() ) return _T("") ;
     wxString ret = was[n] ;
@@ -147,7 +147,7 @@ void EILB::Clear ()
     data.Clear () ;
     }
 
-void EILB::Set ( int id , wxString s , wxString t )
+void EILB::Set ( const int id , const wxString& s , const wxString& t )
     {
     while ( was.GetCount() <= id ) was.Add ( _T("") ) ;
     while ( data.GetCount() <= id ) data.Add ( _T("") ) ;
@@ -196,14 +196,14 @@ EIpanel::EIpanel ( wxWindow *parent , int _mode ) : wxPanel ( parent )
     }
 
 
-wxString EIpanel::valFC ( TiXmlNode *n )
+wxString EIpanel::valFC ( TiXmlNode *n ) const
     {
     if ( !n ) return _T("") ;
     if ( !n->FirstChild() ) return _T("") ;
     return val ( n->FirstChild() ) ;
     }
 
-wxString EIpanel::val ( TiXmlNode *n )
+wxString EIpanel::val ( TiXmlNode *n ) const
     {
     if ( !n ) return _T("") ;
     if ( !n->Value() ) return _T("") ;
@@ -286,7 +286,7 @@ void EIpanel::process ()
     wxEndBusyCursor () ;
     }
 
-wxString EIpanel::num2html ( int num , int digits )
+wxString EIpanel::num2html ( const int num , const int digits ) const
     {
     wxString s = wxString::Format ( _T("%d") , num ) ;
     while ( s.length() < digits ) s = _T(" ") + s ;
@@ -294,7 +294,7 @@ wxString EIpanel::num2html ( int num , int digits )
     return s ;
     }
 
-void EIpanel::showMessage ( wxString msg )
+void EIpanel::showMessage ( const wxString& msg )
     {
     if ( !st_msg->IsShown() )
         {

--- a/ExternalInterface.h
+++ b/ExternalInterface.h
@@ -38,11 +38,11 @@ class EILB : public wxHtmlListBox
     {
     public :
     EILB ( wxWindow *parent , int id = wxID_ANY ) ; ///< Constructor
-    virtual wxString OnGetItem(size_t n) const ; ///< Get the item string
+    virtual wxString OnGetItem(const size_t n) const ; ///< Get the item string
     virtual void Clear () ; ///< Clear the list box
     virtual void Sort () ; ///< Sort the list box
     virtual void Update () ; ///< Update the list box
-    virtual void Set ( int id , wxString s , wxString t = _T("") ) ; ///< Set an entry
+    virtual void Set ( const int id , const wxString& s , const wxString& t = _T("") ) ; ///< Set an entry
 
     wxArrayString was , data ;
     } ;
@@ -55,15 +55,17 @@ class EIpanel : public wxPanel
 
 //  private :
     virtual void process () ; ///< Runs the query, as process_blast or process_ncbi
-    virtual wxString num2html ( int num , int digits ) ; ///< Returns a HTML-formatted number
-    void showMessage ( wxString msg ) ; ///< Displays a message beneath the search controls
+    virtual wxString num2html ( const int num , const int digits ) const ; ///< Returns a HTML-formatted number
+    void showMessage ( const wxString& msg ) ; ///< Displays a message beneath the search controls
+
+    wxString ExecuteHttpsQuery ( const wxString& url ) ; // knows how to execute https queries
 
     virtual void init_blast() ; ///< Initialized BLAST interface
     virtual void process_blast() ; ///< Processes BLAST command, starts thread
     virtual void process_blast2() ; ///< Processes thread results
     virtual void execute_blast_b3() ; ///< Opens the associated link
     virtual void execute_blast() ; ///< Opens returned BLAST entry
-    virtual wxString blast_align ( wxString qseq , wxString mseq , wxString hseq , int cpl , int qoff , int hoff ) ;
+    virtual wxString blast_align ( const wxString& qseq , const wxString& mseq , const wxString& hseq , const int cpl , const int qoff , const int hoff ) ;
 
     virtual void init_ncbi() ; ///< Initializes NCBI interface
     virtual void process_ncbi() ; ///< Processes NCBI request
@@ -80,8 +82,8 @@ class EIpanel : public wxPanel
     virtual void OnC1 ( wxCommandEvent& WXUNUSED(event) ) ; ///< Choice box 1 event handler
     virtual void OnLboxDClick ( wxCommandEvent& WXUNUSED(event) ) ; ///< List box double click event handler
 
-    virtual wxString val ( TiXmlNode *n ) ; ///< Return safe value
-    virtual wxString valFC ( TiXmlNode *n ) ; ///< Return value of FirstChild
+    virtual wxString val ( TiXmlNode *n ) const ; ///< Return safe value
+    virtual wxString valFC ( TiXmlNode *n ) const ; ///< Return value of FirstChild
 
     int mode ;
     wxPanel *up ;

--- a/INSTALL
+++ b/INSTALL
@@ -15,18 +15,20 @@ You can use Dev-C++ as development environment. ".dev" files are
 included in the source. You'll need the latest wxWindows package (look
 on the wxWindows site rather than the Dev-C++ site).
 
-MAC:
+MAC OS:
 
 This software was initially developed for the MacOS, at a time when the
 PowerPC was a thing, still. We recently had success with Xcode, but that
-requires much tinkering to adapt to local install paths of the
-build-dependencies. For now, we find it much easier to work with conda or
-homebrew as described for Linux.
+requires much tinkering to adapt to local install paths of the build-dependencies.
+We find it much easier to work with conda or homebrew (https://brew.sh).
+For details, see the respective description of homebrew/conda below, i.e.
+in the Linux section.
 
-We are providing the target "macos_bundle" that, with what is provided
-by homebrew " crafts a folder named "GENtle.app" that can be copied as it
-is into Applications folder on any Mac of the same architecture for a complete
-deployment.
+The application runs fine when started in situ directly after the compilation.
+To facilitate the deployment on MacOS, we are providing the target "macos_bundle"
+that, with the help of the additional package "dylibbundler" (provided by homebrew),
+assembles a folder named "GENtle.app" that can be copied as it is into the
+"Applications" folder on any Mac of the same architecture for a complete deployment.
 
 LINUX:
 


### PR DESCRIPTION
This PR reinstates the NCBI web interface by using https instead of http, which is a bit tricky with wxWidgets. Because of a need to pass an object that could accept events, the code could not just substitute the SendHTTP routines. Fixes issue https://github.com/GENtle-persons/gentle-m/issues/66. 

The retrieval of papers and sequences does work just fine (looks nice!). Blast yet failed.