### PR TITLE
github: Introducing workflow artifact

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -36,3 +36,12 @@ jobs:
         run: ./configure
       - name: make
         run: make
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: GENtle_${{ matrix.os }}
+          path: |
+            GENtle
+            variables.csv
+            marker.txt
+          retention-days: 10


### PR DESCRIPTION
I am still somewhat uncertain about where this is all heading, but if this works as anticipated then the binary built with the CI can be accessed via the workflow that executed the build. GitHub's Ubuntu image is too old for GENtle to build because of wxWidgets, but the MacOS' binary should be fine. If this works then at some point Ubuntu should be back and also an automated cross-building for Windows should be possible.