### PR TITLE
Codeql fix: rare memory leak, #seqs now size_t for readSeq

### DIFF
--- a/CloningAssistant.cpp
+++ b/CloningAssistant.cpp
@@ -577,12 +577,12 @@ void TDDR::do_highlight ( const wxPoint& p )
     else highlight = DDR_HIGHLIGHT_AS ;
     }
 
-void TDDR::duplicate_from ( TDDR * const b ) // FIXME: This sounds like trouble, should be a contructor
+void TDDR::duplicate_from ( const TDDR * const b ) // FIXME: This sounds like trouble, should be a contructor
     {
     TDDR *old_parent = parent ;
-    clear_children () ;
+    clear_children () ;		    // deleted the children pointed to and the vector itself
     *this = *b ;
-    children.clear () ;		    // FIXME: This would also free children of b
+    children.clear () ;		    // clears only the vector, not the objects pointed to, i.e. the copied values
 
     while ( children.size() < b->children.size() )
         {
@@ -599,7 +599,7 @@ void TDDR::insert_new_child ( TDDR *i , TDDR *t , const bool before )
     {
     VDDR c2 ;
     c2 = children ;
-    children.clear () ;
+    children.clear () ; // frees the vector, not the object it points to
     for ( unsigned int a = 0 ; a < c2.size() ; a++ )
         {
         if ( c2[a] == t )

--- a/CloningAssistant.cpp
+++ b/CloningAssistant.cpp
@@ -464,7 +464,7 @@ void TDDR::clear_children ()
     children.clear () ;
     }
 
-void TDDR::draw ( wxDC &dc , wxPoint off )
+void TDDR::draw ( wxDC &dc , const wxPoint& off )
     {
     if ( original )
         {
@@ -551,7 +551,7 @@ TDDR *TDDR::findItem ( const wxPoint& p , const wxPoint& ori , TDDR *match )
     return this ;
     }
 
-wxPoint TDDR::getRealOffset ()
+wxPoint TDDR::getRealOffset () const
     {
     wxPoint p ( 0 , 0 ) ;
     if ( parent ) p = parent->getRealOffset () ;
@@ -595,7 +595,7 @@ void TDDR::duplicate_from ( TDDR * const b ) // FIXME: This sounds like trouble,
     parent = old_parent ;
     }
 
-void TDDR::insert_new_child ( TDDR *i , TDDR *t , bool before )
+void TDDR::insert_new_child ( TDDR *i , TDDR *t , const bool before )
     {
     VDDR c2 ;
     c2 = children ;

--- a/CloningAssistant.cpp
+++ b/CloningAssistant.cpp
@@ -313,19 +313,19 @@ void TCloningAssistantPanel::arrange ()
                             ca->vlist->r.GetTop() ,
                             cs.GetWidth() - ca->vlist->r.GetRight() - 10 ,
                             ca->vlist->r.GetHeight() ) ;
-    for ( int a = 0 ; a < ca->tlist->children.size() ; a++ )
+    for ( unsigned int a = 0 ; a < ca->tlist->children.size() ; a++ )
         {
         TDDR *i = ca->tlist->children[a] ;
         i->r = wxRect (
             5 ,
-            ca->tlist->r.GetHeight() * a / ca->tlist->children.size() + 5 ,
+            static_cast<unsigned int>(ca->tlist->r.GetHeight()) * a / static_cast<unsigned int>(ca->tlist->children.size()) + 5 ,
             ca->tlist->r.GetWidth() - 10 ,
             ca->tlist->r.GetHeight() / ca->tlist->children.size() - 10
             ) ;
         if ( a == 0 ) i->brush = wxBrush ( wxColour ( 200 , 200 , 200 ) ) ;
 
         // Sort children
-        for ( int b = 1 ; b < i->children.size() ; b++ )
+        for ( unsigned int b = 1 ; b < i->children.size() ; b++ )
             {
             if ( !i->children[b]->item ) continue ;
             if ( !i->children[b-1]->item ) continue ;
@@ -339,7 +339,7 @@ void TCloningAssistantPanel::arrange ()
             }
 
         int lastx = 5 ;
-        for ( int b = 0 ; b < i->children.size() ; b++ )
+        for ( unsigned int b = 0 ; b < i->children.size() ; b++ )
             {
             int c ;
             for ( c = b - 1 ; c >= 0 ; c-- )
@@ -353,10 +353,10 @@ void TCloningAssistantPanel::arrange ()
                  i->children[c]->item->to + 50 < i->children[b]->item->from )
                 break ;
                 }
-            if ( c >= 0 &&
-                 ( i->children[b]->item->getType() != VIT_CDS ||
-                     i->children[c]->item->getType() != VIT_CDS )
-                ) lastx += 15 ;
+            if ( c >= 0 && ( i->children[b]->item->getType() != VIT_CDS || i->children[c]->item->getType() != VIT_CDS ))
+		{
+		lastx += 15 ;
+		}
             i->children[b]->resizeForText ( dc ) ;
             i->children[b]->r.x = lastx + 5 ;
             i->children[b]->r.y = 25 ;
@@ -375,7 +375,12 @@ void TCloningAssistantPanel::do_drop ( TDDR *source , TDDR *target )
     {
     if ( ( source->dragging & target->type & DDR_AS_SEQUENCE ) > 0 ) // Sequence
         {
-        for ( int a = 0 ; a < ca->tlist->children.size() ; a++ )
+	if ( ! ca->tlist )
+	    {
+	    wxPrintf( "E: TCloningAssistantPanel::do_drop: ! ca->tlist\n" ) ;
+	    exit( -1 ) ;
+	    }
+        for ( unsigned int a = 0 ; a < ca->tlist->children.size() ; a++ )
             {
             if ( ca->tlist->children[a] != target ) continue ;
             int drag = a ? DDR_AS_ITEM : DDR_NONE ;
@@ -384,6 +389,11 @@ void TCloningAssistantPanel::do_drop ( TDDR *source , TDDR *target )
             ca->vectors[a] = nv ;
             delete ca->tlist->children[a] ;
             ca->tlist->children[a] = ca->new_from_vector ( nv , drag ) ;
+            if ( ! ca->tlist->children[a] )
+                {
+                wxPrintf("E: TCloningAssistantPanel::do_drop: could not allocate new child from vector.\n" ) ;
+                exit( -1 ) ;
+                }
             ca->tlist->children[a]->parent = ca->tlist ;
             break ;
             }
@@ -438,8 +448,19 @@ TDDR::~TDDR ()
 
 void TDDR::clear_children ()
     {
-    for ( int a = 0 ; a < children.size() ; a++ )
-        delete children[a] ;
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
+        {
+        if (children[a])
+            {
+            delete children[a] ;
+            children[a] = NULL ;
+            }
+        else
+            {
+            wxPrintf( "E: TDDR::clear_children: Found NULL amongst children.\n" ) ;
+            exit( -1 ) ;
+            }
+        }
     children.clear () ;
     }
 
@@ -459,8 +480,7 @@ void TDDR::draw ( wxDC &dc , wxPoint off )
     if ( highlight == DDR_HIGHLIGHT_AS ) dc.SetPen ( ThickRedPen ) ;
     else dc.SetPen ( pen ) ;
     dc.SetBrush ( brush ) ;
-    dc.DrawRectangle ( r.GetLeft() + off.x , r.GetTop() + off.y ,
-                        r.GetWidth() , r.GetHeight() ) ;
+    dc.DrawRectangle ( r.GetLeft() + off.x , r.GetTop() + off.y , r.GetWidth() , r.GetHeight() ) ;
     wxPoint p = wxPoint ( r.GetLeft() + off.x , r.GetTop() + off.y ) ;
     if ( !title.IsEmpty() ) dc.DrawText ( title , p.x + 2 , p.y + 2 ) ;
 
@@ -485,7 +505,7 @@ void TDDR::draw ( wxDC &dc , wxPoint off )
         }
 
     // Update children
-    for ( int a = 0 ; a < children.size() ; a++ )
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
         {
         if ( !children[a]->dragging ) children[a]->draw ( dc , p ) ;
         }
@@ -512,7 +532,7 @@ void TDDR::resizeForText ( wxDC &dc )
     r.SetHeight ( h + 4 ) ;
     }
 
-TDDR *TDDR::findItem ( wxPoint p , wxPoint ori , TDDR *match )
+TDDR *TDDR::findItem ( const wxPoint& p , const wxPoint& ori , TDDR *match )
     {
     if ( dragging ) return NULL ;
     wxRect rr = r ;
@@ -540,7 +560,7 @@ wxPoint TDDR::getRealOffset ()
     return p ;
     }
 
-void TDDR::do_highlight ( wxPoint p )
+void TDDR::do_highlight ( const wxPoint& p )
     {
     if ( ( type & DDR_AS_SEQUENCE ) > 0 )
         {
@@ -557,12 +577,12 @@ void TDDR::do_highlight ( wxPoint p )
     else highlight = DDR_HIGHLIGHT_AS ;
     }
 
-void TDDR::duplicate_from ( TDDR *b )
+void TDDR::duplicate_from ( TDDR * const b ) // FIXME: This sounds like trouble, should be a contructor
     {
     TDDR *old_parent = parent ;
     clear_children () ;
     *this = *b ;
-    children.clear () ;
+    children.clear () ;		    // FIXME: This would also free children of b
 
     while ( children.size() < b->children.size() )
         {

--- a/CloningAssistant.h
+++ b/CloningAssistant.h
@@ -43,11 +43,11 @@ class TDDR // Drag'n'Drop Rect
     ~TDDR () ;
     void resizeForText ( wxDC &dc ) ;
     void draw ( wxDC &dc , wxPoint off = wxPoint ( 0 , 0 ) ) ;
-    TDDR *findItem ( wxPoint p , wxPoint ori = wxPoint ( 0 , 0 ) , TDDR *match = NULL ) ;
+    TDDR *findItem ( const wxPoint& p , const wxPoint& ori = wxPoint ( 0 , 0 ) , TDDR *match = NULL ) ;
     wxPoint getRealOffset () ;
     void clear_children () ;
-    void do_highlight ( wxPoint p ) ;
-    void duplicate_from ( TDDR *b ) ;
+    void do_highlight ( const wxPoint& p ) ;
+    void duplicate_from ( TDDR * const b ) ;
     void insert_new_child ( TDDR *i , TDDR *t , bool before ) ;
 
     wxRect r ;
@@ -90,7 +90,7 @@ class TCloningAssistantPanel : public wxScrolledWindow
     DECLARE_EVENT_TABLE()
     } ;
 
-/**    \brief The cloning assistant module
+/** \brief The cloning assistant module
 */
 class TCloningAssistant : public ChildBase
     {

--- a/CloningAssistant.h
+++ b/CloningAssistant.h
@@ -42,13 +42,13 @@ class TDDR // Drag'n'Drop Rect
     TDDR ( int _type = DDR_NONE ) ;
     ~TDDR () ;
     void resizeForText ( wxDC &dc ) ;
-    void draw ( wxDC &dc , wxPoint off = wxPoint ( 0 , 0 ) ) ;
+    void draw ( wxDC &dc , const wxPoint& off = wxPoint ( 0 , 0 ) ) ;
     TDDR *findItem ( const wxPoint& p , const wxPoint& ori = wxPoint ( 0 , 0 ) , TDDR *match = NULL ) ;
-    wxPoint getRealOffset () ;
+    wxPoint getRealOffset () const ;
     void clear_children () ;
     void do_highlight ( const wxPoint& p ) ;
     void duplicate_from ( TDDR * const b ) ;
-    void insert_new_child ( TDDR *i , TDDR *t , bool before ) ;
+    void insert_new_child ( TDDR *i , TDDR *t , const bool before ) ;
 
     wxRect r ;
     int draggable ;

--- a/CloningAssistant.h
+++ b/CloningAssistant.h
@@ -47,7 +47,7 @@ class TDDR // Drag'n'Drop Rect
     wxPoint getRealOffset () const ;
     void clear_children () ;
     void do_highlight ( const wxPoint& p ) ;
-    void duplicate_from ( TDDR * const b ) ;
+    void duplicate_from ( const TDDR * const b ) ;
     void insert_new_child ( TDDR *i , TDDR *t , const bool before ) ;
 
     wxRect r ;

--- a/MyChild.cpp
+++ b/MyChild.cpp
@@ -740,7 +740,7 @@ void MyChild::initPanels ()
 
     vec->recalculateCuts () ;
 
-     SeqFeature *seqF = NULL ;
+    SeqFeature *seqF = NULL ;
     if ( !vec->getGenomeMode() ) seqF = new SeqFeature ( cSequence ) ;
     SeqDNA *seq = new SeqDNA ( cSequence ) ;
     SeqRestriction *seqR = new SeqRestriction ( cSequence ) ;

--- a/SCFtype.cpp
+++ b/SCFtype.cpp
@@ -12,8 +12,8 @@ typedef signed   short int  int_2;
 typedef unsigned char  uint_1;
 typedef signed   char   int_1;
 
-/**	\typedef SCF_Header
-	\brief Type definition for the SCF_Header structure
+/**    \typedef SCF_Header
+    \brief Type definition for the SCF_Header structure
  */
 typedef struct {
     uint_4 magic_number;
@@ -33,24 +33,24 @@ typedef struct {
     uint_4 spare[18];        ///< Unused
 } SCF_Header;
 
-/**	\typedef SCF_Samples1
-	\brief Type definition for the SCF_Samples1 data
+/** \typedef SCF_Samples1
+    \brief Type definition for the SCF_Samples1 data
  */
 typedef struct {
-        uint_1 sample_A;           ///< Sample for A trace
-        uint_1 sample_C;           ///< Sample for C trace
-        uint_1 sample_G;           ///< Sample for G trace
-        uint_1 sample_T;           ///< Sample for T trace
+    uint_1 sample_A;           ///< Sample for A trace
+    uint_1 sample_C;           ///< Sample for C trace
+    uint_1 sample_G;           ///< Sample for G trace
+    uint_1 sample_T;           ///< Sample for T trace
 } SCF_Samples1;
 
-/**	\typedef SCF_Samples2
-	\brief Type definition for the SCF_Samples2 data
+/**    \typedef SCF_Samples2
+    \brief Type definition for the SCF_Samples2 data
  */
 typedef struct {
-        uint_2 sample_A;           ///< Sample for A trace
-        uint_2 sample_C;           ///< Sample for C trace
-        uint_2 sample_G;           ///< Sample for G trace
-        uint_2 sample_T;           ///< Sample for T trace
+    uint_2 sample_A;           ///< Sample for A trace
+    uint_2 sample_C;           ///< Sample for C trace
+    uint_2 sample_G;           ///< Sample for G trace
+    uint_2 sample_T;           ///< Sample for T trace
 } SCF_Samples2 ;
 
 /*
@@ -70,283 +70,291 @@ typedef struct {
 
 // GENtle stuff
 
-uint_4 get_real_uint4 ( uint_4 x )
-	{
-	unsigned char *c = (unsigned char*) (&x) ;
-	uint_4 u = 0 ;
-	u |= *(c+0) ;
-	u <<= 8 ;
-	u |= *(c+1) ;
-	u <<= 8 ;
-	u |= *(c+2) ;
-	u <<= 8 ;
-	u |= *(c+3) ;
-	return u ;
-	}
+static uint_4 get_real_uint4 ( const uint_4 x )
+    {
+    const unsigned char *c = (unsigned char*) (&x) ;
+    uint_4 u = 0 ;
+    u |= *(c+0) ;
+    u <<= 8 ;
+    u |= *(c+1) ;
+    u <<= 8 ;
+    u |= *(c+2) ;
+    u <<= 8 ;
+    u |= *(c+3) ;
+    return u ;
+    }
 
-void make_real_uint4 ( uint_4 &x )
-	{
-	x = get_real_uint4 ( x ) ;
-	}
+static void make_real_uint4 ( uint_4 &x )
+    {
+    x = get_real_uint4 ( x ) ;
+    }
 
-uint_2 get_real_uint2 ( uint_2 x )
-	{
-	unsigned char *c = (unsigned char*) (&x) ;
-	uint_2 ret = 0 ;
-	ret |= *(c+1) ;
-	ret <<= 8 ;
-	ret |= *(c+0) ;
-	return ret ;
-	}
+static uint_2 get_real_uint2 ( const uint_2 x )
+    {
+    const unsigned char *c = (unsigned char*) (&x) ;
+    uint_2 ret = 0 ;
+    ret |= *(c+1) ;
+    ret <<= 8 ;
+    ret |= *(c+0) ;
+    return ret ;
+    }
 
 
 SCFtype::SCFtype ()
-	{
-	}
-
-bool SCFtype::parse ( const wxString& filename )
-	{
-	wxFile f ( filename , wxFile::read ) ;
-	long l = f.Length() ;
-	unsigned char *t = new unsigned char [l+15] ;
-	f.Read ( t , l ) ;
-	f.Close() ;
-
-	if ( *(t+0) != '.' || *(t+1) != 's' || *(t+2) != 'c' || *(t+3) != 'f' )
-		{
-		delete [] t ;
-		return false ; // No luck
-		}
-
-	SCF_Header *header = (SCF_Header*) t ;
-
-	wxString version ;
-	version += (*header).version[0] ;
-	version += (*header).version[1] ;
-	version += (*header).version[2] ;
-	version += (*header).version[3] ;
-	if ( (*header).version[0] < '3' )
-		{
-		wxMessageBox ( _T("Cannot read SFC prior to 3.0, this is ") + version ) ;
-                delete [] t;
-		return false ;
-		}
-
-	// Requires SCF V3.0 from here on!
-	make_real_uint4 ( (*header).comments_size ) ;
-	make_real_uint4 ( (*header).comments_offset ) ;
-	make_real_uint4 ( (*header).bases ) ;
-	make_real_uint4 ( (*header).bases_offset ) ;
-	make_real_uint4 ( (*header).samples ) ;
-	make_real_uint4 ( (*header).samples_offset ) ;
-	make_real_uint4 ( (*header).sample_size ) ;
-
-	if ( (*header).samples == 0 || (*header).bases == 0 ) return false ; // Paranoia
-
-	unsigned char *c ;
-	unsigned int a ;
-
-	// Read comment
-	sd.comment.Empty() ;
-	for ( a = 0 , c = t + (*header).comments_offset ; a < (*header).comments_size ; a++ , c++ )
-		sd.comment += *c ;
-
-	// Preparing to read sequence information
-	void *v = t + (*header).bases_offset ;
-	unsigned long *ulp ;
-	sd.sequence.clear () ;
-	sd.seq.Empty () ;
-	for ( a = 0 , ulp = (unsigned long*) v ; a < (*header).bases ; a++ , ulp++ )
-		{
-		TSequencerDataSequenceItem si ;
-		si.peak_index = get_real_uint4 ( *ulp ) ;
-		sd.sequence.push_back ( si ) ;
-		}
-
-	// Reading sequence data
-	for ( a = 0 ; a < 5 ; a++ )
-		{
-		v = t + (*header).bases_offset + (*header).bases * ( 4 + a ) ;
-		read_data_block ( v , a ) ;
-		}
-
-	// Sorting sequence data; might be unnecessary
-	for ( a = 1 ; a < sd.sequence.size() ; a++ )
-		{
-		if ( sd.sequence[a-1].peak_index <= sd.sequence[a].peak_index ) continue ;
-		TSequencerDataSequenceItem d = sd.sequence[a-1] ;
-		sd.sequence[a-1] = sd.sequence[a] ;
-		sd.sequence[a] = d ;
-		a = 0 ;
-		}
-
-/*
-	// Maximum trace data
-	unsigned long min = 9999 , max = 0 ;
-	for ( a = 0 ; a < sd.sequence.size() ; a++ )
-		{
-		if ( max < sd.sequence[a].peak_index ) max = sd.sequence[a].peak_index ;
-		if ( min > sd.sequence[a].peak_index ) min = sd.sequence[a].peak_index ;
-		}
-	if ( max >= sd.tracer.size() ) return false ; // Paranoia
-*/
-
-	// Read tracer data
-	sd.tracer.clear () ;
-	while ( sd.tracer.size() < (*header).samples )
-		sd.tracer.push_back ( TSequencerDataTracerItem () ) ;
-	for ( a = 0 ; a < 4 ; a++ )
-		{
-		unsigned long offset = (*header).samples_offset + (*header).samples * a * (*header).sample_size ;
-		v = t + offset ;
-		read_tracer_block ( v , a , (*header).sample_size ) ;
-		}
-
-	// Fix tracer diff diff hell
-	for ( a = 0 ; a < 4 ; a++ )
-		fix_diff ( a ) ;
-
-	// Setup alternative tracer data set
-	for ( a = 0 ; a < 4 ; a++ ) sd.tracer2[a].clear () ;
-	for ( a = 0 ; a < sd.tracer.size() ; a++ )
-		{
-		TSequencerDataTracerItem ti = sd.tracer[a] ;
-		sd.tracer2[TRACER_ID_A].push_back ( ti.data[0] ) ;
-		sd.tracer2[TRACER_ID_C].push_back ( ti.data[1] ) ;
-		sd.tracer2[TRACER_ID_G].push_back ( ti.data[2] ) ;
-		sd.tracer2[TRACER_ID_T].push_back ( ti.data[3] ) ;
-		}
-
-
-	wxFile out ( _T("C:\\test.txt") , wxFile::write ) ;
-	for ( a = 0 ; a < sd.sequence.size() ; a++ )
-	{
-		out.Write ( wxString::Format ( _T("%5d: %5d %c\r\n") , a , sd.sequence[a].peak_index , sd.sequence[a].base ) ) ;
+    {
     }
 
-/*
-	// THE FOLLOWING MESS MIGHT PROVE USEFUL ONE DAY
-	// TO IMPORT SCF VERSIONS 1 AND 2 AS WELL
-	v += (*header).bases * 4
-	for ( a = 0 , base = (SCF_Base*) v ; a < (*header).bases ; a++ , base++ )
-		{
-		TSequencerDataSequenceItem si = sd[a] ;
-//		si.peak_index = get_real_uint4 ( (*base).peak_index ) ;
-		si.prob_a = (*base).prob_A ;
-		si.prob_c = (*base).prob_C ;
-		si.prob_g = (*base).prob_G ;
-		si.prob_t = (*base).prob_T ;
+bool SCFtype::parse ( const wxString& filename )
+    {
+    wxFile f ( filename , wxFile::read ) ;
+    long l = f.Length() ;
+    unsigned char *t = new unsigned char [l+15] ;
+    f.Read ( t , l ) ;
+    f.Close() ;
 
-		char c = 'A' ;
-		int prob = si.prob_a ;
-		if ( prob < si.prob_c ) { prob = si.prob_c ; c = 'C' ; }
-		if ( prob < si.prob_g ) { prob = si.prob_g ; c = 'G' ; }
-		if ( prob < si.prob_t ) { prob = si.prob_t ; c = 'T' ; }
-		sd.seq += c ;
+    if ( *(t+0) != '.' || *(t+1) != 's' || *(t+2) != 'c' || *(t+3) != 'f' )
+        {
+        delete [] t ;
+        return false ; // No luck
+        }
 
-		si.base = (*base).base ;
-		sd[a] = si ;
-//		sd.sequence.push_back ( si ) ;
-//		out += wxString::Format ( _T("%d:%c\n\r\n") , si.peak_index , si.base ) ;
-		}
+    SCF_Header *header = (SCF_Header*) t ;
 
-	// Read samples
-	SCF_Samples1 *s1 = NULL ;
-	SCF_Samples2 *s2 = NULL ;
-	v = t + (*header).samples_offset ;
-	bool use_word = (*header).sample_size == 2 ;
-	if ( use_word ) s2 = (SCF_Samples2 *) v ;
-	else s1 = (SCF_Samples1 *) v ;
-	sd.tracer.clear () ;
-	for ( a = 0 ; a < 4 ; a++ ) sd.tracer2[a].clear () ;
-	for ( a = 0 ; a < (*header).samples ; a++ )
-		{
-		TSequencerDataTracerItem ti ;
-		ti.a = use_word ? get_real_uint2 ( s2->sample_A ) : s1->sample_A ;
-		ti.c = use_word ? get_real_uint2 ( s2->sample_C ) : s1->sample_C ;
-		ti.g = use_word ? get_real_uint2 ( s2->sample_G ) : s1->sample_G ;
-		ti.t = use_word ? get_real_uint2 ( s2->sample_T ) : s1->sample_T ;
-//		out += wxString::Format ( _T("%d,%d,%d,%d; ") , ti.a , ti.c , ti.g , ti.t ) ;
-		sd.tracer.push_back ( ti ) ;
-		sd.tracer2[TRACER_ID_A].push_back ( ti.a ) ;
-		sd.tracer2[TRACER_ID_C].push_back ( ti.c ) ;
-		sd.tracer2[TRACER_ID_G].push_back ( ti.g ) ;
-		sd.tracer2[TRACER_ID_T].push_back ( ti.t ) ;
-		if ( use_word ) s2++ ;
-		else s1++ ;
-		}
+    wxString version ;
+    version += (*header).version[0] ;
+    version += (*header).version[1] ;
+    version += (*header).version[2] ;
+    version += (*header).version[3] ;
+    if ( (*header).version[0] < '3' )
+        {
+        wxMessageBox ( _T("Cannot read SFC prior to 3.0, this is ") + version ) ;
+        delete [] t;
+        return false ;
+        }
 
-	for ( a = 1 ; a < sd.sequence.size() ; a++ )
-		{
-		if ( sd.sequence[a-1].peak_index <= sd.sequence[a].peak_index ) continue ;
-		TSequencerDataSequenceItem d = sd.sequence[a-1] ;
-		sd.sequence[a-1] = sd.sequence[a] ;
-		sd.sequence[a] = d ;
-		a = 0 ;
-		}
-*/
-//	wxMessageBox ( out ) ;
-//	wxMessageBox ( sd.comment ) ;
+    // Requires SCF V3.0 from here on!
+    make_real_uint4 ( (*header).comments_size ) ;
+    make_real_uint4 ( (*header).comments_offset ) ;
+    make_real_uint4 ( (*header).bases ) ;
+    make_real_uint4 ( (*header).bases_offset ) ;
+    make_real_uint4 ( (*header).samples ) ;
+    make_real_uint4 ( (*header).samples_offset ) ;
+    make_real_uint4 ( (*header).sample_size ) ;
 
-	delete [] t ;
-	return true ;
+    if ( (*header).samples == 0 || (*header).bases == 0 ) return false ; // Paranoia
+
+    // Read comment
+    sd.comment.Empty() ;
+    {
+    unsigned int aa=0;
+    unsigned char *c = t + (*header).comments_offset ; 
+    while (aa++ < (*header).comments_size )
+        {
+        sd.comment += *c ;
+        c++ ;
+        }
+    }
+
+    // Preparing to read sequence information
+    void *v = t + (*header).bases_offset ;
+    sd.sequence.clear () ;
+    sd.seq.Empty () ;
+    {
+    unsigned long *ulp = (unsigned long*) v ;
+    unsigned int aa = 0;
+    while ( aa++  < (*header).bases )
+        {
+        TSequencerDataSequenceItem si ;
+        si.peak_index = get_real_uint4 ( *ulp ) ;
+        sd.sequence.push_back ( si ) ;
+        ulp++ ;
 	}
+    }
+
+    // Reading sequence data
+    for ( unsigned int a = 0 ; a < 5 ; a++ )
+        {
+        v = t + (*header).bases_offset + (*header).bases * ( 4 + a ) ;
+        read_data_block ( v , a ) ;
+        }
+
+    // Sorting sequence data; might be unnecessary
+    for ( unsigned int a = 1 ; a < sd.sequence.size() ; a++ )
+        {
+        if ( sd.sequence[a-1].peak_index <= sd.sequence[a].peak_index ) continue ;
+        TSequencerDataSequenceItem d = sd.sequence[a-1] ;
+        sd.sequence[a-1] = sd.sequence[a] ;
+        sd.sequence[a] = d ;
+        a = 0 ;
+        }
+
+/*
+    // Maximum trace data
+    unsigned long min = 9999 , max = 0 ;
+    for ( a = 0 ; a < sd.sequence.size() ; a++ )
+        {
+        if ( max < sd.sequence[a].peak_index ) max = sd.sequence[a].peak_index ;
+        if ( min > sd.sequence[a].peak_index ) min = sd.sequence[a].peak_index ;
+        }
+    if ( max >= sd.tracer.size() ) return false ; // Paranoia
+*/
+
+    // Read tracer data
+    sd.tracer.clear () ;
+    while ( sd.tracer.size() < (*header).samples )
+        sd.tracer.push_back ( TSequencerDataTracerItem () ) ;
+    for ( unsigned int a = 0 ; a < 4 ; a++ )
+        {
+        unsigned long offset = (*header).samples_offset + (*header).samples * a * (*header).sample_size ;
+        v = t + offset ;
+        read_tracer_block ( v , a , (*header).sample_size ) ;
+        }
+
+    // Fix tracer diff diff hell
+    for ( unsigned int a = 0 ; a < 4 ; a++ )
+        fix_diff ( a ) ;
+
+    // Setup alternative tracer data set
+    for ( unsigned int a = 0 ; a < 4 ; a++ ) sd.tracer2[a].clear () ;
+    for ( unsigned int a = 0 ; a < sd.tracer.size() ; a++ )
+        {
+        TSequencerDataTracerItem ti = sd.tracer[a] ;
+        sd.tracer2[TRACER_ID_A].push_back ( ti.data[0] ) ;
+        sd.tracer2[TRACER_ID_C].push_back ( ti.data[1] ) ;
+        sd.tracer2[TRACER_ID_G].push_back ( ti.data[2] ) ;
+        sd.tracer2[TRACER_ID_T].push_back ( ti.data[3] ) ;
+        }
+
+
+    wxFile out ( _T("C:\\test.txt") , wxFile::write ) ;
+    for ( size_t a = 0 ; a < sd.sequence.size() ; a++ )
+        {
+        out.Write ( wxString::Format ( _T("%5d: %5d %c\r\n") , a , sd.sequence[a].peak_index , sd.sequence[a].base ) ) ;
+        }
+
+/*
+    // THE FOLLOWING MESS MIGHT PROVE USEFUL ONE DAY
+    // TO IMPORT SCF VERSIONS 1 AND 2 AS WELL
+    v += (*header).bases * 4
+    for ( a = 0 , base = (SCF_Base*) v ; a < (*header).bases ; a++ , base++ )
+        {
+        TSequencerDataSequenceItem si = sd[a] ;
+//        si.peak_index = get_real_uint4 ( (*base).peak_index ) ;
+        si.prob_a = (*base).prob_A ;
+        si.prob_c = (*base).prob_C ;
+        si.prob_g = (*base).prob_G ;
+        si.prob_t = (*base).prob_T ;
+
+        char c = 'A' ;
+        int prob = si.prob_a ;
+        if ( prob < si.prob_c ) { prob = si.prob_c ; c = 'C' ; }
+        if ( prob < si.prob_g ) { prob = si.prob_g ; c = 'G' ; }
+        if ( prob < si.prob_t ) { prob = si.prob_t ; c = 'T' ; }
+        sd.seq += c ;
+
+        si.base = (*base).base ;
+        sd[a] = si ;
+//        sd.sequence.push_back ( si ) ;
+//        out += wxString::Format ( _T("%d:%c\n\r\n") , si.peak_index , si.base ) ;
+        }
+
+    // Read samples
+    SCF_Samples1 *s1 = NULL ;
+    SCF_Samples2 *s2 = NULL ;
+    v = t + (*header).samples_offset ;
+    bool use_word = (*header).sample_size == 2 ;
+    if ( use_word ) s2 = (SCF_Samples2 *) v ;
+    else s1 = (SCF_Samples1 *) v ;
+    sd.tracer.clear () ;
+    for ( a = 0 ; a < 4 ; a++ ) sd.tracer2[a].clear () ;
+    for ( a = 0 ; a < (*header).samples ; a++ )
+        {
+        TSequencerDataTracerItem ti ;
+        ti.a = use_word ? get_real_uint2 ( s2->sample_A ) : s1->sample_A ;
+        ti.c = use_word ? get_real_uint2 ( s2->sample_C ) : s1->sample_C ;
+        ti.g = use_word ? get_real_uint2 ( s2->sample_G ) : s1->sample_G ;
+        ti.t = use_word ? get_real_uint2 ( s2->sample_T ) : s1->sample_T ;
+//        out += wxString::Format ( _T("%d,%d,%d,%d; ") , ti.a , ti.c , ti.g , ti.t ) ;
+        sd.tracer.push_back ( ti ) ;
+        sd.tracer2[TRACER_ID_A].push_back ( ti.a ) ;
+        sd.tracer2[TRACER_ID_C].push_back ( ti.c ) ;
+        sd.tracer2[TRACER_ID_G].push_back ( ti.g ) ;
+        sd.tracer2[TRACER_ID_T].push_back ( ti.t ) ;
+        if ( use_word ) s2++ ;
+        else s1++ ;
+        }
+
+    for ( a = 1 ; a < sd.sequence.size() ; a++ )
+        {
+        if ( sd.sequence[a-1].peak_index <= sd.sequence[a].peak_index ) continue ;
+        TSequencerDataSequenceItem d = sd.sequence[a-1] ;
+        sd.sequence[a-1] = sd.sequence[a] ;
+        sd.sequence[a] = d ;
+        a = 0 ;
+        }
+*/
+//    wxMessageBox ( out ) ;
+//    wxMessageBox ( sd.comment ) ;
+
+    delete [] t ;
+    return true ;
+    }
 
 void SCFtype::read_tracer_block ( void *v , unsigned int mode , unsigned int sample_size )
-	{
-	unsigned int a , samples = sd.tracer.size() ;
-	unsigned char *c = (unsigned char*) v ;
-	unsigned long lastx = 0 ;
-	for ( a = 0 ; a < samples ; a++ )
-		{
-		unsigned long x = 0 ;
-		if ( sample_size == 2 )
-			{
-			x |= (unsigned char) *(c+0) ;
-			x <<= 8 ;
-			x |= (unsigned char) *(c+1) ;
+    {
+    unsigned int samples = sd.tracer.size() ;
+    unsigned char *c = (unsigned char*) v ;
+    unsigned long lastx = 0 ;
+    for ( unsigned int a = 0 ; a < samples ; a++ )
+        {
+        unsigned long x = 0 ;
+        if ( sample_size == 2 )
+            {
+            x |= (unsigned char) *(c+0) ;
+            x <<= 8 ;
+            x |= (unsigned char) *(c+1) ;
 
-			if ( x >= 32768 ) {
+            if ( x >= 32768 ) {
                 x = x - 65536 ;
             }
 
-			c += 2 ;
-			}
-		else x = *c++ ;
+            c += 2 ;
+            }
+        else x = *c++ ;
         sd.tracer[a].data[mode] = x ;
-		}
-	}
+        }
+    }
 
 void SCFtype::read_data_block ( void *v , unsigned int mode )
-	{
-	unsigned int a , bases = sd.sequence.size() ;
-	unsigned char *c = (unsigned char*) v ;
-	for ( a = 0 ; a < bases ; a++ , c++ )
-		{
-		switch ( mode )
-			{
-			case 0 : sd.sequence[a].prob_a = *c ; break ;
-			case 1 : sd.sequence[a].prob_c = *c ; break ;
-			case 2 : sd.sequence[a].prob_g = *c ; break ;
-			case 3 : sd.sequence[a].prob_t = *c ; break ;
-			case 4 : sd.sequence[a].base = *c ; sd.seq += *c ; break ;
-			}
-		}
-	}
+    {
+    unsigned int bases = sd.sequence.size() ;
+    unsigned char *c = (unsigned char*) v ;
+    for ( unsigned int a = 0 ; a < bases ; a++ , c++ )
+        {
+        switch ( mode )
+            {
+            case 0 : sd.sequence[a].prob_a = *c ; break ;
+            case 1 : sd.sequence[a].prob_c = *c ; break ;
+            case 2 : sd.sequence[a].prob_g = *c ; break ;
+            case 3 : sd.sequence[a].prob_t = *c ; break ;
+            case 4 : sd.sequence[a].base = *c ; sd.seq += *c ; break ;
+            }
+        }
+    }
 
-void SCFtype::fix_diff ( int mode )
-	{
-	signed long p_sample = 0;
-	unsigned long i , num_samples = sd.tracer.size() ;
-	for ( i = 0 ; i < num_samples ; i++ )
-		{
-		p_sample += sd.tracer[i].data[mode] ;
-		sd.tracer[i].data[mode] = p_sample ;
-		}
-	p_sample = 0 ;
-	for ( i = 0 ; i < num_samples ; i++ )
-		{
-		p_sample += sd.tracer[i].data[mode] ;
-		sd.tracer[i].data[mode] = p_sample ;
-		}
-	}
+void SCFtype::fix_diff ( const int mode )
+    {
+    signed long p_sample = 0;
+    unsigned long num_samples = sd.tracer.size() ;
+    for ( size_t i = 0 ; i < num_samples ; i++ )
+        {
+        p_sample += sd.tracer[i].data[mode] ;
+        sd.tracer[i].data[mode] = p_sample ;
+        }
+    p_sample = 0 ;
+    for ( size_t i = 0 ; i < num_samples ; i++ )
+        {
+        p_sample += sd.tracer[i].data[mode] ;
+        sd.tracer[i].data[mode] = p_sample ;
+        }
+    }

--- a/SCFtype.h
+++ b/SCFtype.h
@@ -17,7 +17,7 @@ class SCFtype
 	private :
 	void read_data_block ( void *v , unsigned int mode ) ;
 	void read_tracer_block ( void *v , unsigned int mode , unsigned int sample_size ) ;
-	void fix_diff ( int mode ) ;
+	void fix_diff ( const int mode ) ;
 	} ;
 
 #endif

--- a/SequenceCanvas.h
+++ b/SequenceCanvas.h
@@ -461,15 +461,15 @@ class SeqPlot : public SeqDNA
     private :
     virtual void scanMinMax () ; ///< Determine minimum/maximum values
     virtual void scanChouFasman ( const int x , const int y , const int t , const int min , const int seek_cnt , const int seek_avg , const int avg ) ;
-    virtual void drawSymbol ( const char c , wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) ;
+    virtual void drawSymbol ( const char c , wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) const ;
     virtual void showChouFasman ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) ; ///< Display Chou-Fasman
-    virtual void showNcoils ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) ; ///< Display Coiled-coil
+    virtual void showNcoils ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) const ; ///< Display Coiled-coil
     virtual void showMW ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) ; ///< Display molecular weight
     virtual void showPI ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) ; ///< Display isoelectric point
     virtual void showHP ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) ; ///< Display hydrophobicity
-    virtual void fixMinMax ( float &f ) ; ///< What the hell does this do??
-    virtual void drawDottedLine ( wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) ; ///< Draws a horizontal/vertical helper line
-    virtual void myRect ( wxDC &dc , const int x , const int y , const int w , const int h ) ; ///< Draws a "special" rectangle
+    virtual void fixMinMax ( float &f ) const ; ///< What the hell does this do??
+    virtual void drawDottedLine ( wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) const ; ///< Draws a horizontal/vertical helper line
+    virtual void myRect ( wxDC &dc , const int x , const int y , const int w , const int h ) const ; ///< Draws a "special" rectangle
     enum { CHOU_FASMAN , P_I , M_W , H_P , COILED_COIL } type ;
     int lines , l_top, l_bottom ;
     wxArrayString d1 , d2 , d3 ;

--- a/SequenceTypePlot.cpp
+++ b/SequenceTypePlot.cpp
@@ -18,7 +18,7 @@ wxString SeqPlot::getTip ( int pos )
 int SeqPlot::arrange ( int n )
     {
     if ( s.IsEmpty() ) return 0 ;
-    int a , x , y , w , h , l = 0 , bo = can->border , lowy = 0 ;
+    int x , y , w , h , l = 0 , bo = can->border , lowy = 0 ;
     int lasta = 0 ;
 
     // Setting basic values
@@ -44,27 +44,29 @@ int SeqPlot::arrange ( int n )
     x = ox ;
     y = oy ;
     pos.add ( -(++l) , bo , y , ox-wx-bo , wy-1 ) ; // Line number
-    for ( a = 0 ; a < s.length() ; a++ )
+    for ( int a = 0 ; a < s.length() ; a++ )
         {
         if ( can->isMiniDisplay() && can->getAA() && can->getAA()->miniDisplayOptions == MINI_DISPLAY_CONDENSED )
-           x = ox + ( w - ox ) * a / s.length() ;
+            {
+            x = ox + ( w - ox ) * a / static_cast<unsigned int>(s.length()) ;
+            }
         pos.add ( a+1 , x , y , wx-1 , wy*lines-1 ) ;
         can->setLowX ( x + wx*2 ) ;
         lowy = y+wy*lines ;
         x += wx ;
         if ( (a+1) % can->blocksize == 0 )
-           {
-           x += wx-1 ;
-           if ( x+wx*(can->blocksize+1) >= w )
-              {
-              pos.addline ( lasta , pos.p.GetCount() , y , y+wy*lines-1 ) ;
-              lasta = pos.p.GetCount()+1 ;
-              x = ox ;
-              y += wy * ( can->seq.GetCount() + can->blankline ) ;
-              if ( a+1 < s.length() )
-                 pos.add ( -(++l) , bo , y , ox-wx-5 , wy-1 ) ; // Line number
-              }
-           }
+            {
+            x += wx-1 ;
+            if ( x+wx*(can->blocksize+1) >= w )
+                {
+                pos.addline ( lasta , pos.p.GetCount() , y , y+wy*lines-1 ) ;
+                lasta = pos.p.GetCount()+1 ;
+                x = ox ;
+                y += wy * ( can->seq.GetCount() + can->blankline ) ;
+                if ( a+1 < s.length() )
+                    pos.add ( -(++l) , bo , y , ox-wx-5 , wy-1 ) ; // Line number
+                }
+            }
         }
     if ( lasta != pos.p.GetCount()+1 )
         pos.addline ( lasta , pos.p.GetCount() , y , y+wy*lines-1 ) ;
@@ -75,44 +77,47 @@ int SeqPlot::arrange ( int n )
 // Display
 
 
-void SeqPlot::drawDottedLine ( wxDC &dc , int x1 , int y1 , int x2 , int y2 )
+void SeqPlot::drawDottedLine ( wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) const
     {
     if ( can->isPrinting() )
         {
         dc.DrawLine ( x1 , y1 , x2 , y2 ) ;
         return ;
         }
-    int i ;
     if ( x1 == x2 )
         {
-        for ( i = y1 ; i <= y2 ; i++ )
-           if ( i & 1 ) dc.DrawPoint ( x1 , i ) ;
+        for ( int i = y1 ; i <= y2 ; i++ )
+            if ( i & 1 ) dc.DrawPoint ( x1 , i ) ;
         }
     else
         {
-        for ( i = x1 ; i <= x2 ; i++ )
-           if ( i & 1 ) dc.DrawPoint ( i , y1 ) ;
+        for ( int i = x1 ; i <= x2 ; i++ )
+            if ( i & 1 ) dc.DrawPoint ( i , y1 ) ;
         }
     }
 
-void SeqPlot::myRect ( wxDC &dc , int x , int y , int w , int h )
+void SeqPlot::myRect ( wxDC &dc , const int x , const int y , const int w , const int h ) const
     {
     if ( can->isPrinting() )
         {
         for ( int i = 0 ; i <= h ; i++ )
-           dc.DrawLine ( x , y+i , x+w , y+i ) ;
-        return ;
+            {
+            dc.DrawLine ( x , y+i , x+w , y+i ) ;
+            }
         }
-    for ( int i = 0 ; i < w ; i++ )
+    else
         {
-        for ( int j = 0 ; j < h ; j++ )
-           {
-           if ( ( x+i + y+j ) & 1 ) dc.DrawPoint ( x + i , y + j ) ;
-           }
+        for ( int i = 0 ; i < w ; i++ )
+            {
+            for ( int j = 0 ; j < h ; j++ )
+                {
+                if ( ( x+i + y+j ) & 1 ) dc.DrawPoint ( x + i , y + j ) ;
+                }
+            }
         }
     }
 
-void SeqPlot::fixMinMax ( float &f )
+void SeqPlot::fixMinMax ( float &f ) const
     {
     f = f > data_max ? data_max : f ;
     f = f < data_min ? data_min : f ;
@@ -239,12 +244,12 @@ void SeqPlot::show ( wxDC& dc )
     dc.SetTextForeground ( tfg ) ;
     }
 
-void SeqPlot::showMW ( wxDC &dc , int b , int tx , int ty , int lx )
+void SeqPlot::showMW ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) /* not const */
     {
     int ch = can->charheight / 2 ;
     int cw = can->charwidth ;
     int bottom = ty + lines * can->charheight ;
-    for ( int u = 1 ; u < d1.GetCount() ; u++ )
+    for ( unsigned int u = 1 ; u < d1.GetCount() ; u++ )
         {
         int tz = ty + (u-1) * ch + 1 ;
         int tw = ( tx + cw ) - lx ;
@@ -256,33 +261,33 @@ void SeqPlot::showMW ( wxDC &dc , int b , int tx , int ty , int lx )
             }
         }
 
-    showPlot ( dc , b , tx , ty , lx , bottom - ty - ch ) ;
+        showPlot ( dc , b , tx , ty , lx , bottom - ty - ch ) ; // not const (should be)
     }
 
-void SeqPlot::showPI ( wxDC &dc , int b , int tx , int ty , int lx )
+void SeqPlot::showPI ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) /* not const */
     {
     // All the same...
-    showMW ( dc , b , tx , ty , lx ) ;
+    showMW ( dc , b , tx , ty , lx ) ; // not const because of showPlot
     }
 
-void SeqPlot::showHP ( wxDC &dc , int b , int tx , int ty , int lx )
+void SeqPlot::showHP ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) /* not const */
     {
     // All the same...
-    showMW ( dc , b , tx , ty , lx ) ;
+    showMW ( dc , b , tx , ty , lx ) ; // not const because of showPlot
     }
 
-void SeqPlot::showNcoils ( wxDC &dc , int b , int tx , int ty , int lx )
+void SeqPlot::showNcoils ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) const
     {
     }
 
-void SeqPlot::showChouFasman ( wxDC &dc , int b , int tx , int ty , int lx )
+void SeqPlot::showChouFasman ( wxDC &dc , const int b , const int tx , const int ty , const int lx ) /* not const */
     {
 //     mylog ( "SeqPlot::showChouFasman" , "1" ) ;
     int bottom = ty + lines * can->charheight ;
     int ch = can->charheight / 2 ;
     int cw = can->charwidth ;
 //  mylog ( "SeqPlot::showChouFasman" , "2" ) ;
-    for ( int u = 1 ; u < d1.GetCount() ; u++ )
+    for ( unsigned int u = 1 ; u < d1.GetCount() ; u++ )
         {
         const wxPen *pen = wxRED_PEN ;
         if ( u == 2 ) pen = wxGREEN_PEN ;
@@ -334,16 +339,16 @@ void SeqPlot::showChouFasman ( wxDC &dc , int b , int tx , int ty , int lx )
         }
 
 //  mylog ( "SeqPlot::showChouFasman" , "3" ) ;
-    showPlot ( dc , b , tx , ty , lx , bottom - d1.GetCount() * ch - ty ) ;
+    showPlot ( dc , b , tx , ty , lx , bottom - d1.GetCount() * ch - ty ) ; // not const
 //  mylog ( "SeqPlot::showChouFasman" , "4" ) ;
     }
 
 
-void SeqPlot::showPlot ( wxDC &dc , int b , int tx , int ty , int lx , int ph )
+void SeqPlot::showPlot ( wxDC &dc , const int b , const int tx , const int ty , const int lx , const int ph ) /* not const */
     {
     mylog ( "SeqPlot::showPlot" , "1" ) ;
     if ( !can->isMiniDisplay() ) return ;
-    if ( ((int)data_h) == 0 ) data_h = 1 ;//return ; // Flat data or something...
+    if ( ((int)data_h) == 0 ) data_h = 1 ; // not const //return ; // Flat data or something...
     mylog ( "SeqPlot::showPlot" , "2" ) ;
     int ch = can->charheight ;
     int cw = can->charwidth ;
@@ -428,30 +433,29 @@ void SeqPlot::showPlot ( wxDC &dc , int b , int tx , int ty , int lx , int ph )
     mylog ( "SeqPlot::showPlot" , "8" ) ;
     }
 
-void SeqPlot::drawSymbol ( char c , wxDC &dc , int x1 , int y1 , int x2 , int y2 )
+void SeqPlot::drawSymbol ( const char c , wxDC &dc , const int x1 , const int y1 , const int x2 , const int y2 ) const
     {
     dc.SetPen(*wxBLACK_PEN);
     int w = x2 - x1 ;
     int h = y2 - y1 ;
     if ( c == 'T' )
         {
-        x2--; w--; y1++; h--;
-        int y3 = y2 - h/4 ;
-        dc.DrawLine ( x1 , y1 , x2 - w/3 , y1 ) ;
-        dc.DrawLine ( x1 , y3 , x2 - w/3 , y3 ) ;
-        dc.DrawArc ( x2 - w/3 , y3 , x2 - w/3 , y1 , x2 - w/3 , (y1+y3)/2 ) ;
+        int y3 = y2 - (h-1)/4 ;
+        dc.DrawLine ( x1 , y1+1 , (x2-1) - (w-1)/3 , y1+1 ) ;
+        dc.DrawLine ( x1 , y3 , (x2-1) - (w-1)/3 , y3 ) ;
+        dc.DrawArc ( (x2-1) - (w-1)/3 , y3 , (x2-1) - (w-1)/3 , y1+1 , (x2-1) - (w-1)/3 , (y1+1+y3)/2 ) ;
         dc.SetPen(*wxWHITE_PEN);
-        dc.DrawLine ( x2 - w/3 , y3-1 , x2 - w/3 , y1+1 ) ;
+        dc.DrawLine ( (x2-1) - (w-1)/3 , y3-1 , (x2-1) - (w-1)/3 , y1+1+1 ) ;
         dc.SetPen(*wxBLACK_PEN);
-        dc.DrawLine ( x1 , y3 , x1 + w*2/3 , y3 - h/2 ) ;
-        dc.DrawLine ( x1 , y3 , x1 + w*2/3 , y3 + h/2 ) ;
+        dc.DrawLine ( x1 , y3 , x1 + (w-1)*2/3 , y3 - (h-1)/2 ) ;
+        dc.DrawLine ( x1 , y3 , x1 + (w-1)*2/3 , y3 + (h-1)/2 ) ;
         }
     else if ( c == 'b' )
         {
-        x1 += w/2 - h/6 ;
-        dc.DrawLine ( x1 , y1 , x1 , y2 ) ;
-        dc.DrawArc ( x1 , y1+h/3 , x1 , y1 , x1 , y1+h/6 ) ;
-        dc.DrawArc ( x1 , y1+h*2/3 , x1 , y1+h/3 , x1 , y1+h*3/6 ) ;
+        int _x1 = x1 + w/2 - h/6 ;
+        dc.DrawLine ( _x1 , y1 , _x1 , y2 ) ;
+        dc.DrawArc ( _x1 , y1+h/3 , _x1 , y1 , _x1 , y1+h/6 ) ;
+        dc.DrawArc ( _x1 , y1+h*2/3 , _x1 , y1+h/3 , _x1 , y1+h*3/6 ) ;
         }
     else if ( c == 'a' )
         {
@@ -468,7 +472,7 @@ void SeqPlot::drawSymbol ( char c , wxDC &dc , int x1 , int y1 , int x2 , int y2
 
 // Communication with the outside world :-)
 
-void SeqPlot::init ( SequenceCanvas *ncan )
+void SeqPlot::init ( SequenceCanvas * const ncan )
     {
     SeqBasic::init ( ncan ) ;
     hp_window = 7 ;
@@ -690,7 +694,7 @@ void SeqPlot::scanMinMax ()
     data_h = data_max - data_min ;
     }
 
-void SeqPlot::scanChouFasman ( int x , int y , int t , int min , int seek_cnt , int seek_avg , int avg )
+void SeqPlot::scanChouFasman ( const int x , const int y , const int t , const int min , const int seek_cnt , const int seek_avg , const int avg )
     {
     for ( uint p = 0 ; p + y < s.length() ; p++ )
         {

--- a/TPhyloTree.cpp
+++ b/TPhyloTree.cpp
@@ -230,19 +230,17 @@ void TPhyloTree::setModeStrange ()
     r.Deflate ( 10 , 10 ) ;
 
     int md = tree->getMaxDepth() ;
-    int a , b ;
-    for ( a = 0 ; a < md ; a++ )
+    for ( unsigned int a = 0 ; a < md ; a++ )
         {
         vector <TPTree*> vt ;
         tree->filterDepth ( a+1 , vt ) ;
-        for ( b = 0 ; b < vt.size() ; b++ )
+        for ( unsigned int b = 0 ; b < vt.size() ; b++ )
             {
             int tw = -5 , th = -5 ;
             if ( vt[b]->isLeaf() ) dc.GetTextExtent ( vt[b]->getName() , &tw , &th ) ;
-            wxRect r2 (    r.GetLeft() + r.GetWidth() * a / md ,
-                            r.GetTop() + r.GetHeight() * b / vt.size() ,
-                            tw + 5 ,
-                            th + 5 ) ;
+            wxRect r2 ( r.GetLeft() + static_cast<unsigned int>(r.GetWidth() * a) / md ,
+                        r.GetTop() + static_cast<unsigned int>(r.GetHeight() * b) / vt.size() ,
+                        tw + 5 , th + 5 ) ;
             vt[b]->rect = r2 ;
             }
         }
@@ -268,9 +266,10 @@ void TPhyloTree::setModeDrawgram ()
     vector <TPTree*> vt ;
     tree->getAll ( vt ) ;
 
-    int a , b , maxw = 0 ;
+    unsigned int maxw = 0 ;
     for ( int n = 0 ; n < 2 ; n++ )
         {
+        unsigned int a , b ;
         for ( a = b = 0 ; a < vt.size() ; a++ )
             {
             if ( !vt[a]->isLeaf() ) continue ;
@@ -280,9 +279,9 @@ void TPhyloTree::setModeDrawgram ()
             xf *= vt[a]->getCurrentWeight() ;
             xf /= mw ;
             wxRect r2 ( r.GetLeft() + xf ,
-                            r.GetTop() + r.GetHeight() * b / mc ,
-                            tw + border ,
-                            th + border ) ;
+                        r.GetTop() + static_cast<unsigned int>(r.GetHeight() * b) / mc ,
+                        tw + border ,
+                        th + border ) ;
             vt[a]->rect = r2 ;
             if ( r2.GetWidth() > maxw ) maxw = r2.GetWidth() ;
             b++ ;
@@ -290,7 +289,7 @@ void TPhyloTree::setModeDrawgram ()
         }
 
     tree->averageY () ;
-    for ( a = 0 ; a < vt.size() ; a++ )
+    for ( unsigned int a = 0 ; a < vt.size() ; a++ )
         {
         if ( vt[a]->isLeaf() ) continue ;
         vt[a]->rect.SetHeight ( 0 ) ;
@@ -350,8 +349,8 @@ void TPhyloTreeBox::OnEvent(wxMouseEvent& event)
 
 void TPhyloTreeBox::WriteIntoBitmap(wxBitmap &bmp)
     {
-     int w , h ;
-     GetClientSize ( &w , &h ) ;
+    int w , h ;
+    GetClientSize ( &w , &h ) ;
     bmp = wxBitmap ( w , h , wxDisplayDepth() ) ;
     wxMemoryDC memdc ;
     memdc.SelectObject ( bmp ) ;
@@ -369,12 +368,12 @@ void TPhyloTreeBox::OnSaveAsBitmap(wxCommandEvent &event)
 void TPhyloTreeBox::OnCopy(wxCommandEvent &event)
     {
     if (wxTheClipboard->Open())
-      {
-      wxBitmap bmp ;
-      WriteIntoBitmap ( bmp ) ;
-      wxTheClipboard->SetData( new wxBitmapDataObject ( bmp ) );
-      wxTheClipboard->Close();
-      }
+        {
+        wxBitmap bmp ;
+        WriteIntoBitmap ( bmp ) ;
+        wxTheClipboard->SetData( new wxBitmapDataObject ( bmp ) );
+        wxTheClipboard->Close();
+        }
     }
 
 void TPhyloTreeBox::OnPrint(wxCommandEvent &event)
@@ -392,8 +391,7 @@ TPTree::TPTree ()
 
 TPTree::~TPTree ()
     {
-    int a ;
-    for ( a = 0 ; a < children.size() ; a++ )
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
         delete children[a] ;
     }
 wxString TPTree::scanNewick ( wxString s ) /* not const */
@@ -444,8 +442,8 @@ wxString TPTree::scanNewick ( wxString s ) /* not const */
 
 double TPTree::getMaxWeight () const
     {
-    double x = 0 ;
-    for ( int a = 0 ; a < children.size() ; a++ )
+    double x = 0.0 ;
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
         {
         double y = children[a]->getMaxWeight() ;
         if ( y > x ) x = y ;
@@ -462,7 +460,7 @@ double TPTree::getCurrentWeight () const
 int TPTree::getMaxDepth () const
     {
     int r = getCurrentDepth() ;
-    for ( int a = 0 ; a < children.size() ; a++ )
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
         {
         int x = children[a]->getMaxDepth() ;
         if ( x > r ) r = x ;
@@ -484,7 +482,7 @@ int TPTree::countLeafs () const
     return cnt ;
     }
 
-int TPTree::numberLeafs ( int i ) /* not const */
+unsigned int TPTree::numberLeafs ( unsigned int i ) /* not const */
     {
     if ( isLeaf () )
         {
@@ -494,7 +492,7 @@ int TPTree::numberLeafs ( int i ) /* not const */
 
     // Not a leaf
     leafNumber = 0 ;
-    for ( int a = 0 ; a < children.size() ; a++ )
+    for ( unsigned int a = 0 ; a < children.size() ; a++ )
         i = children[a]->numberLeafs ( i ) ;
     return i ;
     }
@@ -553,7 +551,7 @@ void TPTree::filterDepth ( const int depth , vector <TPTree*> &vt ) /* const */
     if ( getCurrentDepth() == depth )
         {
         vt.push_back ( this ) ; // not const
-//        return ;
+//      return ;
         }
 
     for ( int a = 0 ; a < children.size() ; a++ )

--- a/TPhyloTree.h
+++ b/TPhyloTree.h
@@ -21,7 +21,7 @@ class TPTree
     virtual int getMaxDepth () const ;
     virtual int getCurrentDepth () const ;
     virtual int countLeafs () const ;
-    virtual int numberLeafs ( int i = 0 ) ;
+    virtual unsigned int numberLeafs ( unsigned int i = 0 ) ;
 
     virtual void filterDepth ( const int depth , vector <TPTree*> &vt ) ;
     virtual void getAll ( vector <TPTree*> &vt ) ;
@@ -38,7 +38,7 @@ class TPTree
     double weight ;
     wxString name ;
     TPTree* parent ;
-    int leafNumber ;
+    unsigned int leafNumber ;
     } ;
 
 /**    \class TPhyloTree

--- a/TSequencerData.h
+++ b/TSequencerData.h
@@ -12,9 +12,9 @@ class TSequencerDataTracerItem
 class TSequencerDataSequenceItem
     {
     public :
-    unsigned long peak_index ;
-    unsigned char prob_a , prob_c , prob_t , prob_g ;
-    char base ;
+    unsigned long peak_index = 0L ;
+    unsigned char prob_a = 0 , prob_c = 0 , prob_t = 0 , prob_g = 0 ;
+    char base = 0 ;
     } ;
 
 class TSequencerData

--- a/TUReadSeq.cpp
+++ b/TUReadSeq.cpp
@@ -40,12 +40,11 @@ void TUReadSeq::getSequences () /* not const */
     seqs.Clear () ;
     for ( size_t seqIndex = 0 ; error == 0 && seqIndex < seq_names.GetCount() ; seqIndex++ )
         {
-        size_t seqlen;     /* length of seq */
+        size_t seqlen;     /* length of seq */ // expected signed by readSeq
         char  seqid[256]; /* sequence name */
         char  *seq;       /* sequence, 0 terminated, free when done */
         seqid[0] = 0 ;
-        seq = readSeq( seqIndex+1, filename.mb_str(), skiplines, format,
-                      &seqlen, &numseqs, &error, seqid);
+        seq = readSeq( seqIndex+1, filename.mb_str(), skiplines, format, &seqlen, &numseqs, &error, seqid);
         for ( char *c = seq ; *c ; c++ )
            {
            if ( *c >= 'a' && *c <= 'z' ) *c = *c - 'a' + 'A' ;

--- a/TUReadSeq.cpp
+++ b/TUReadSeq.cpp
@@ -38,19 +38,19 @@ void TUReadSeq::getSequences () /* not const */
     {
     if ( error != 0 ) return ;
     seqs.Clear () ;
-    for ( short seqIndex = 1 ; error == 0 && seqIndex <= seq_names.GetCount() ; seqIndex++ )
+    for ( size_t seqIndex = 0 ; error == 0 && seqIndex < seq_names.GetCount() ; seqIndex++ )
         {
-        long  seqlen;     /* length of seq */
+        size_t seqlen;     /* length of seq */
         char  seqid[256]; /* sequence name */
         char  *seq;       /* sequence, 0 terminated, free when done */
         seqid[0] = 0 ;
-        seq = readSeq( seqIndex, filename.mb_str(), skiplines, format,
+        seq = readSeq( seqIndex+1, filename.mb_str(), skiplines, format,
                       &seqlen, &numseqs, &error, seqid);
         for ( char *c = seq ; *c ; c++ )
            {
            if ( *c >= 'a' && *c <= 'z' ) *c = *c - 'a' + 'A' ;
            }
-        seq_names[seqIndex-1] = wxString ( seqid , *wxConvCurrent ) ;
+        seq_names[seqIndex] = wxString ( seqid , *wxConvCurrent ) ;
         seqs.Add ( wxString ( seq , *wxConvCurrent) ) ; // not const
         free(seq);
         }

--- a/TUReadSeq.h
+++ b/TUReadSeq.h
@@ -27,8 +27,8 @@ class TUReadSeq
     private :
     wxString filename ; ///< Name of source file
     short format ;
-    short numseqs ;
-    long skiplines ;
+    size_t numseqs ;
+    size_t skiplines ;
     wxArrayString seq_names ;
     wxArrayString seqs ;
     } ;

--- a/TVectorEditorItems.cpp
+++ b/TVectorEditorItems.cpp
@@ -349,16 +349,30 @@ void TVectorEditor::itemAdd ( wxCommandEvent &ev )
 void TVectorEditor::itemDel ( wxCommandEvent &ev )
     {
     int i = getCurrentItem() ;
-    if ( i == -1 ) return ;
+    if ( i == -1 )
+        {
+        wxPrintf("W: TVectorEditor::itemDel: Nothing to delete. Why am I called?\n") ;
+        return ;
+        }
     storeItemData () ;
     delete newitems[i] ;
     newitems.RemoveAt ( i ) ;
     makeItemsList () ;
     itemClr () ;
-    while ( i >= 0 && i >= newitems.GetCount() ) i-- ;
-    if ( i < 0 ) return ;
-    items->SetItemState ( newitems[i]->r4 , wxLIST_STATE_SELECTED , wxLIST_STATE_SELECTED ) ;
-    items->EnsureVisible ( newitems[i]->r4 ) ;
+    int j = i;
+    if (j >= newitems.GetCount())
+        {
+        // i was last element in list
+        j = newitems.GetCount() - 1 ;
+        }
+    if ( j < 0 )
+        {
+        wxPrintf("I: TVectorEditor::itemDel: Removed last element.\n") ;
+        return ;
+        }
+    // Choosing next element to highlight - if reaching to this point.
+    items->SetItemState ( newitems[j]->r4 , wxLIST_STATE_SELECTED , wxLIST_STATE_SELECTED ) ;
+    items->EnsureVisible ( newitems[j]->r4 ) ;
     }
 
 void TVectorEditor::itemClr ()

--- a/TVectorEditorItems.cpp
+++ b/TVectorEditorItems.cpp
@@ -351,12 +351,13 @@ void TVectorEditor::itemDel ( wxCommandEvent &ev )
     int i = getCurrentItem() ;
     if ( i == -1 )
         {
-        wxPrintf("W: TVectorEditor::itemDel: Nothing to delete. Why am I called?\n") ;
+        wxPrintf( "W: TVectorEditor::itemDel: Nothing to delete. Why am I called?\n" ) ;
         return ;
         }
     storeItemData () ;
     delete newitems[i] ;
-    newitems.RemoveAt ( i ) ;
+    newitems[i] = NULL ; // just to help the automated error detection
+    newitems.RemoveAt ( i ) ; // removes the pointer (now NULL) at the position i
     makeItemsList () ;
     itemClr () ;
     int j = i;
@@ -367,12 +368,20 @@ void TVectorEditor::itemDel ( wxCommandEvent &ev )
         }
     if ( j < 0 )
         {
-        wxPrintf("I: TVectorEditor::itemDel: Removed last element.\n") ;
+        wxPrintf( "I: TVectorEditor::itemDel: Removed last element.\n" ) ;
         return ;
         }
     // Choosing next element to highlight - if reaching to this point.
-    items->SetItemState ( newitems[j]->r4 , wxLIST_STATE_SELECTED , wxLIST_STATE_SELECTED ) ;
-    items->EnsureVisible ( newitems[j]->r4 ) ;
+    if (0 == newitems[j])
+        {
+	wxPrintf( "E: TVectorEditor::itemDel: newitems[j]  is NULL - should never happen.\n" ) ;
+	exit( -1 ) ;
+        }
+    else
+        {
+        items->SetItemState ( newitems[j]->r4 , wxLIST_STATE_SELECTED , wxLIST_STATE_SELECTED ) ;
+        items->EnsureVisible ( newitems[j]->r4 ) ;
+        }
     }
 
 void TVectorEditor::itemClr ()

--- a/ipc/ipc.cpp
+++ b/ipc/ipc.cpp
@@ -22,7 +22,7 @@
 #include <math.h>
 
 TIPC::TIPC ()
-	{
+    {
     verbindung = NULL ;
     peaks = NULL ;
     fast_calc = 0 ;
@@ -30,37 +30,38 @@ TIPC::TIPC ()
     pars = new TIPC_PARS ( this ) ;
     gpout = new GPOUT ( this ) ;
     element = new TIPC_ELEMENT ( this ) ;
-	}    
+    }    
 
 TIPC::~TIPC ()
-	{
-	}	
+    {
+    // FIXME: Why are pars, gpout and element not deleted?
+    }    
 
 void TIPC::free_list(isotope *target)
 {
-  while(target->next)
-    {
-      target=target->next;
-      free(target->previous);
-    }
-  free(target);
+    while(target->next)
+        {
+        target=target->next;
+        free(target->previous);
+        }
+    free(target);
 }
 
 void TIPC::cut_peaks(isotope *spectrum)
 {
-  int dummy=1;
+    int dummy=1;
 
-  while( (spectrum->next) && (dummy<fast_calc) )
-    {
-      dummy++;
-      spectrum=spectrum->next;
-    }
+    while( (spectrum->next) && (dummy<fast_calc) )
+        {
+        dummy++;
+        spectrum=spectrum->next;
+        }
 
-  if(spectrum->next)
-    {
-      free_list(spectrum->next);
-      spectrum->next=NULL;
-    }
+    if(spectrum->next)
+        {
+        free_list(spectrum->next);
+        spectrum->next=NULL;
+        }
 }
 
 void TIPC::summarize_peaks()
@@ -70,12 +71,12 @@ void TIPC::summarize_peaks()
    /* Differenz wegen Rundungsfehlern */
     while( dummy->next && (dummy->next->mass - dummy->mass < 0.00000001) )
       {
-	d2=dummy->next;
-	dummy->next=d2->next;
-	if(dummy->next)
-	  dummy->next->previous=dummy;
-	dummy->p+=d2->p;
-	free(d2);
+    d2=dummy->next;
+    dummy->next=d2->next;
+    if(dummy->next)
+      dummy->next->previous=dummy;
+    dummy->p+=d2->p;
+    free(d2);
       }
 }
 
@@ -119,85 +120,90 @@ isotope *TIPC::add_peak(isotope *base,isotope *peak)
   return 0;
 }
 
-int TIPC::calculate_peaks(){
-  ipc_compound *c;
-  isotope *npeaks,*p,*i,*np1;
-  int anzahl;
+int TIPC::calculate_peaks()
+    {
+    isotope *npeaks,*p,*i,*np1;
+    int anzahl;
 
-  if(!(peaks=(isotope*)malloc(sizeof(isotope))))
-    return 0;
-  peaks->mass=0;
-  peaks->p=1;
-  peaks->previous=NULL;
-  peaks->next=NULL;
-
-  for(c=verbindung;c;c=c->next){
-    for(anzahl=0;anzahl < c->amount;anzahl++){
-
-      if(!(npeaks=(isotope*)malloc(sizeof(isotope))))
-	return 0;
-      npeaks->mass=0;
-
-      for(p=peaks;p;p=p->next){
-	for(i=c->isotopes;i;i=i->next){
-
-	  if(!(np1=(isotope*)malloc(sizeof(isotope))))
-	    return 0;
-
-	  np1->mass=p->mass + i->mass;
-	  np1->p=p->p * i->p;
-	  if( !(npeaks=add_peak(npeaks,np1)) )
-	    return 0;
+    if(!(peaks=(isotope*)malloc(sizeof(isotope))))
+        {
+        return 0;
 	}
-      }
-      free_list(peaks);
-      peaks=npeaks;
-      summarize_peaks();
-      if(fast_calc)
-	cut_peaks(peaks);
+
+    peaks->mass=0;
+    peaks->p=1;
+    peaks->previous=NULL;
+    peaks->next=NULL;
+
+    for(ipc_compound * c = verbindung ; c; c=c->next )
+        {
+        for(anzahl=0;anzahl < c->amount;anzahl++)
+	    {
+
+            if(!(npeaks=(isotope*)malloc(sizeof(isotope))))
+                return 0;
+            npeaks->mass=0;
+
+            for(p=peaks;p;p=p->next)
+	        {
+                for(i=c->isotopes;i;i=i->next)
+	            {
+                    if(!(np1=(isotope*)malloc(sizeof(isotope))))
+                        return 0;
+
+                    np1->mass=p->mass + i->mass;
+                    np1->p=p->p * i->p;
+                    if( !(npeaks=add_peak(npeaks,np1)) )
+                        return 0;
+                    }
+                }
+            free_list(peaks);
+            peaks=npeaks;
+            summarize_peaks();
+            if(fast_calc) cut_peaks(peaks);
+            }
+        }
+    return 1;
     }
-  }
-  return 1;
-}
 
 
 void TIPC::print_result(int digits,int charge){
-  isotope *d;
-  double maxp=0,relint=0,sump=0;
-  int permutationen=0;
+   isotope *d;
+   double maxp=0,relint=0,sump=0;
+   int permutationen=0;
 
-  printf("\n");
+   printf("\n");
  
-  for(d=peaks;d;d=d->next)
-    {
+   for(d=peaks;d;d=d->next)
+      {
       permutationen++;
       sump+=d->p;
       d->mass=d->mass / charge;
       d->mass=(rint( d->mass * pow(10,digits) ) / pow(10,digits) );
-    }
+     }
 
-  summarize_peaks();
-  for(d=peaks;d;d=d->next)
-    if(d->p > maxp)
-      maxp=d->p;
+   summarize_peaks();
+   for(d=peaks;d;d=d->next)
+       if(d->p > maxp)
+       maxp=d->p;
 
-  for(d=peaks;d;d=d->next)
-    {
-      if( ( relint=(d->p/maxp)*100) > MIN_INT )
-	printf("M= %f, p= %e, rel. Int.= %f%%\n",
-	       d->mass,d->p,relint);
+   for(d=peaks;d;d=d->next)
+       {
+       if( ( relint=(d->p/maxp)*100) > MIN_INT )
+       printf("M= %f, p= %e, rel. Int.= %f%%\n",
+           d->mass,d->p,relint);
+       }
+    if(!(fast_calc))
+        printf("\nNumber of  permutations: %i\n",permutationen);
+    else
+        {
+        sump=(rint(sump*10000)/100); 
+        printf("\nCovered Intensity: %2.2f%% \n",sump);
+        }
     }
-  if(!(fast_calc))
-    printf("\nNumber of  permutations: %i\n",permutationen);
-  else
-    {
-      sump=(rint(sump*10000)/100); 
-      printf("\nCovered Intensity: %2.2f%% \n",sump);
-    }
-}
 
 int TIPC::ipc_main2 ( const char *filename , const char *aaseq , int f )
-	{
+    {
     char *gnuplotfile=NULL;
     
     verbindung=NULL;
@@ -206,19 +212,23 @@ int TIPC::ipc_main2 ( const char *filename , const char *aaseq , int f )
     
     if(!element->init_elements()) return 1 ;
     
-	if(!(gnuplotfile=strdup(filename))) return 1 ;
+    if(!(gnuplotfile=strdup(filename))) return 1 ;
 
-	if(!pars->pars_amino_acid((char*)aaseq)) return 2 ; // -a
+    if(!pars->pars_amino_acid((char*)aaseq)) return 2 ; // -a
 
     if(!calculate_peaks()) return 3 ;
     
     if(!(gpout->make_gnuplot_output(gnuplotfile))) return 4 ;
     
     if ( verbindung ) delete verbindung ;
-    if ( peaks ) delete peaks ;
+    if ( peaks )
+        {
+	free( peaks ) ; // allocated by malloc
+	peaks = NULL ;
+	}
 
-	return 0 ;
-	}    
+    return 0 ;
+    }    
 
 int TIPC::ipc_main(int argc,char **argv){
 /*  long seconds;
@@ -246,117 +256,117 @@ int TIPC::ipc_main(int argc,char **argv){
   while(argv[d])
     {
       if(!strcmp(argv[d],"-f"))
-	{
-	  d++;
-	  if(!argv[d])
-	    {
-	      printf("Missing argument for -f\n");
-	      return 101;
-	    }
-	  fast_calc=strtol(argv[d],NULL,10);
-	}
+    {
+      d++;
+      if(!argv[d])
+        {
+          printf("Missing argument for -f\n");
+          return 101;
+        }
+      fast_calc=strtol(argv[d],NULL,10);
+    }
 
       else if(!strcmp(argv[d],"-z"))
-	{
-	  d++;
-	  if(!argv[d])
-	    {
-	      printf("Missing argument for -z\n");
-	      return 2;
-	    }
-	  charge=strtol(argv[d],NULL,10);
-	}
+    {
+      d++;
+      if(!argv[d])
+        {
+          printf("Missing argument for -z\n");
+          return 2;
+        }
+      charge=strtol(argv[d],NULL,10);
+    }
 
       else if(!strcmp(argv[d],"-d"))
-	{
-	  d++;
-	  if(!argv[d])
-	    {
-	      printf("Missing argument for -d\n");
-	      return 3;
-	    }
-	  use_digits=strtol(argv[d],NULL,10);
-	}
+    {
+      d++;
+      if(!argv[d])
+        {
+          printf("Missing argument for -d\n");
+          return 3;
+        }
+      use_digits=strtol(argv[d],NULL,10);
+    }
 
       else if(!strcmp(argv[d],"-c")){
-	d++;
-	if(!argv[d])
-	  {
-	    printf("Missing argument for -c\n");
-	    return 4;
-	  }
-	 if(!pars_chem_form(argv[d])){
-	   printf("Parser error.\n");
-	   return 5;
-	 }
+    d++;
+    if(!argv[d])
+      {
+        printf("Missing argument for -c\n");
+        return 4;
+      }
+     if(!pars_chem_form(argv[d])){
+       printf("Parser error.\n");
+       return 5;
+     }
       }
 
       else if(!strcmp(argv[d],"-g")){
-	d++;
-	if(!argv[d]){
-	  printf("Missing argument for -g\n");
-	  return 6;
-	}
-	gnuplot=1;
-	if(!(gnuplotfile=strdup(argv[d]))){
-	  printf("Not enough memory\n");
-	  return 7;
-	}
+    d++;
+    if(!argv[d]){
+      printf("Missing argument for -g\n");
+      return 6;
+    }
+    gnuplot=1;
+    if(!(gnuplotfile=strdup(argv[d]))){
+      printf("Not enough memory\n");
+      return 7;
+    }
       }
 
 
       else if(!strcmp(argv[d],"-p")){
-	d++;
-	if(!argv[d]){
-	  printf("Missing argument for -p\n");
-	  return 8;
-	}
-	if(!(pars_peptid(argv[d]))){
-	  printf("Error in peptid parser.\n");
-	  return 9;
-	}
+    d++;
+    if(!argv[d]){
+      printf("Missing argument for -p\n");
+      return 8;
+    }
+    if(!(pars_peptid(argv[d]))){
+      printf("Error in peptid parser.\n");
+      return 9;
+    }
       }
 
       else if(!strcmp(argv[d],"-a")){
-	d++;
-	if(!argv[d]){
-	  printf("Missing argument for -a\n");
-	  return 10;
-	}
-	if(!pars_amino_acid(argv[d])){
-	  printf("Error in pars_amino_acid.\n");
-	  return 11;
-	}
+    d++;
+    if(!argv[d]){
+      printf("Missing argument for -a\n");
+      return 10;
+    }
+    if(!pars_amino_acid(argv[d])){
+      printf("Error in pars_amino_acid.\n");
+      return 11;
+    }
       }
 
       else if(!strcmp(argv[d],"-s"))
-	zeig_summenformel=1;
+    zeig_summenformel=1;
 
       else if(!strcmp(argv[d],"-h"))
-	{
-	  usage();
-	  return 12;
-	}
+    {
+      usage();
+      return 12;
+    }
 
       else if(!strcmp(argv[d],"-x"))
-	calc_peaks=0;
+    calc_peaks=0;
 
       else
-	{
-	  printf("Unknown flag: %s\n",argv[d]);
-	  usage();
-	  return 13;
-	}
+    {
+      printf("Unknown flag: %s\n",argv[d]);
+      usage();
+      return 13;
+    }
       d++;
       }
 
   if(zeig_summenformel)
     {
       if(!print_sum())
-	{
-	  printf("error while showing chemical formula.\n");
-	  return 14;
-	}
+    {
+      printf("error while showing chemical formula.\n");
+      return 14;
+    }
     }
 #ifdef HAVE_TIME
   seconds=time(0);

--- a/ureadseq.h
+++ b/ureadseq.h
@@ -123,42 +123,36 @@ extern  prettyopts  gPretty;
 extern "C" {
 #endif
 
-extern short seqFileFormat(const char *filename, long *skiplines, short *error );
-extern short seqFileFormatFp(FILE *fseq, long  *skiplines, short *error );
+extern short seqFileFormat(const char *filename, size_t *skiplines, short *error );
+extern short seqFileFormatFp(FILE *fseq, size_t  *skiplines, short *error );
 
-extern char *listSeqs(const char *filename, const long skiplines,
-                       const short format, short *nseq, short *error );
+extern char *listSeqs(const char *filename, const size_t skiplines,
+                       const short format, size_t *nseq, short *error );
 
-extern char *readSeq(const short whichEntry, const char *filename,
-                      const long skiplines, const short format,
-                      long *seqlen, short *nseq, short *error, char *seqid );
+extern char *readSeq(const size_t whichEntry, const char *filename,
+                      const size_t skiplines, const short format,
+                      size_t *seqlen, size_t *nseq, short *error, char *seqid );
 
-extern char *readSeqFp(const short whichEntry_, FILE  *fp_,
-  const long  skiplines_, const short format_,
-        long  *seqlen_,  short *nseq_, short *error_, char *seqid_ );
+extern char *readSeqFp(const size_t whichEntry_, FILE  *fp_, const size_t  skiplines_, const short format_, size_t  *seqlen_,  size_t *nseq_, short *error_, char *seqid_ );
 
-extern short writeSeq(FILE *outf, const char *seq, const long seqlen,
-                       const short outform, const char *seqid );
+extern size_t writeSeq(FILE *outf, const char *seq, const size_t seqlen, const short outform, const char *seqid );
 
-extern unsigned long CRC32checksum(const char *seq, const long seqlen, unsigned long *checktotal);
-extern unsigned long GCGchecksum(const char *seq, const long seqlen, unsigned long *checktotal);
+extern unsigned long CRC32checksum(const char *seq, const size_t seqlen, size_t *checktotal);
+extern unsigned long GCGchecksum(const char *seq, const size_t seqlen, size_t *checktotal);
 #ifdef SMALLCHECKSUM
 #define seqchecksum  GCGchecksum
 #else
 #define seqchecksum  CRC32checksum
 #endif
 
-extern short getseqtype(const char *seq, const long seqlen );
-extern char *compressSeq( const char gapc, const char *seq, const long seqlen, long *newlen);
+extern short getseqtype(const char *seq, const size_t seqlen );
+extern char *compressSeq( const char gapc, const char *seq, const size_t seqlen, size_t *newlen);
 
 #ifdef NCBI
 
-extern char *listASNSeqs(const char *filename, const long skiplines,
-                  const short format, short *nseq, short *error );
+extern char *listASNSeqs(const char *filename, const long skiplines, const short format, size_t *nseq, short *error );
 
-extern char *readASNSeq(const short whichEntry, const char *filename,
-                const long skiplines, const short format,
-                long *seqlen, short *nseq, short *error, char **seqid );
+extern char *readASNSeq(const short whichEntry, const char *filename, const size_t skiplines, const short format, size_t *seqlen, size_t *nseq, short *error, char **seqid );
 #endif
 
 


### PR DESCRIPTION
It started with a complaint by codeql about types, and in the age of RNA-seq I wanted the schema to allow to describe a fasta file beyond |shorts|. Have not tested if this affects the alignments (should not be the case), but I have not yet worked on the alignments anyway and with all the advents of additional tools over the last years I already know this will need some extra care - and extra tests.

Also addressed complains about working on uninitialized strings - have not checked the logic but just assingned empty strings to sid and sid1.  