### PR TITLE
feature+fix: min/max constraints, current enzymes now static (smoe: addressing_restriction_enzymes)

### DIFF
--- a/src/PlasmidCanvasLinear.cpp
+++ b/src/PlasmidCanvasLinear.cpp
@@ -4,7 +4,7 @@
 
 void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
 {
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - start\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - start\n" ) ;
     if ( printing ) h = h * 2 / 3 ; // not const
     int fontfactor = MYFONTSIZE * 10 / 8 ;
     if ( printing ) fontfactor = (w>h?h:w)/70 ;
@@ -82,7 +82,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
         }
 
     // Baseline
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Baseline\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Baseline\n" ) ;
     if ( p->vec->showGC() > 0 ) // %GC
         {
         int dh = h / 80 ;
@@ -116,7 +116,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
     else dc.DrawLine ( lineOff , lineH , w - lineOff , lineH ) ;
 
     // Numbers
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Numbers\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Numbers\n" ) ;
     dc.SetFont( smallFont );
     for ( int a = 0 ; a < l ; a += d ) // defined at function entry
         {
@@ -131,7 +131,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
         }
 
     // Methylation sites
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Methylation\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Methylation\n" ) ;
     dc.SetPen(*wxRED_PEN);
     for ( int a = 0 ; a < p->vec->countMethylationSites() ; a++ )
         {
@@ -143,7 +143,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
     dc.SetPen(*wxBLACK_PEN);
 
     // Recalc
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Recalc\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Recalc\n" ) ;
     if ( p->vec->displayUpdate() )
         {
         // Genes, items, etc.
@@ -207,11 +207,11 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
         }
 
     // ORFs
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - ORF\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - ORF\n" ) ;
     drawLinearORFs ( dc ) ;
 
     // Drawing items
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Items\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Items\n" ) ;
     for ( int a = 0 ; a < p->vec->items.size() ; a++ )
         {
         TVectorItem i = p->vec->items[a] ;
@@ -234,7 +234,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
         }
 
     // Drawing Restriction Sites
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Restrictions\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - Restrictions\n" ) ;
     dc.SetFont(tinyFont);
     for ( int a = 0 ; a < p->vec->rc.size() ; a++ )
         {
@@ -254,7 +254,7 @@ void PlasmidCanvas::OnDrawLinear(wxDC& dc) /* not const */
     dc.SetFont( smallFont );
     dc.SetPen ( *wxBLACK_PEN ) ;
     dc.SetTextForeground ( *wxBLACK ) ;
-    wxPrintf( "D: PlasmidCanvas::OnDrawLinear - end\n" ) ;
+    //wxPrintf( "D: PlasmidCanvas::OnDrawLinear - end\n" ) ;
 }
 
 void PlasmidCanvas::drawLinearORFs ( wxDC &dc ) const

--- a/src/ProgramOptionsDialog.cpp
+++ b/src/ProgramOptionsDialog.cpp
@@ -638,6 +638,7 @@ void TEnzymeRules::getVectorCuts ( /* not const */ TVector * const v ) const
     // Getting the default list of enzymes
     wxArrayTRestrictionEnzyme ve ;
     wxArrayString vs ;
+    wxPrintf( "D: TEnzymeRules::getVectorCuts - requesting Enzymes for default group '%s'\n" , default_group ) ;
     myapp()->frame->LS->getEnzymesInGroup ( default_group , vs ) ;
     ve.Alloc ( vs.GetCount() ) ;
 
@@ -677,17 +678,17 @@ void TEnzymeRules::getVectorCuts ( /* not const */ TVector * const v ) const
         {
         vector <TRestrictionCut> vc ;
         v->getCuts ( ve[a] , vc , false , max ) ;
-        if ( use_min_cutoff &&  min_cutoff <= vc.size() )
+        if ( use_min_cutoff &&  min_cutoff > vc.size() )
             {
-            wxPrintf( "D: TEnzymeRules::getVectorCuts - min cutoff - enzyme:%s vc.size():%lu\n" , ve[a]->getName() , vc.size() ) ;
+            wxPrintf( "D: TEnzymeRules::getVectorCuts - min cutoff: %d - skipping enzyme:%s - too few cuts - vc.size():%lu\n" , min_cutoff, ve[a]->getName() , vc.size() ) ;
             }
-        else if ( use_max_cutoff && max_cutoff >= vc.size() )
+        else if ( use_max_cutoff && max_cutoff < vc.size() )
             {
-            wxPrintf( "D: TEnzymeRules::getVectorCuts - max cutoff - enzyme:%s vc.size():%lu\n" , ve[a]->getName() , vc.size() ) ;
+            wxPrintf( "D: TEnzymeRules::getVectorCuts - max cutoff: %d - skipping enzyme:%s - too many cuts - vc.size():%lu\n" , max_cutoff, ve[a]->getName() , vc.size() ) ;
             }
         else
             {
-            wxPrintf( "D: TEnzymeRules::getVectorCuts - accepting - enzyme:%s vc.size():%lu\n" , ve[a]->getName() , vc.size() ) ;
+            wxPrintf( "D: TEnzymeRules::getVectorCuts - accepting - accepting enzyme:%s vc.size():%lu\n" , ve[a]->getName() , vc.size() ) ;
             v->re2.Add ( ve[a] ) ;
             for ( int b = 0 ; b < vc.size() ; b++ )
                 {

--- a/src/TRestrictionEditor.cpp
+++ b/src/TRestrictionEditor.cpp
@@ -282,7 +282,7 @@ void TRestrictionEditor::initRestrictionPage ()
 
 void TRestrictionEditor::listEnzymesInGroup ( const wxString& gr , wxArrayString &vs ) const
     {
-    wxPrintf( "D: TRestrictionEditor::listEnzymesInGroup (gr: %s, vs.GetCount: %lu)\n" , gr, vs.GetCount() ) ;
+    //wxPrintf( "D: TRestrictionEditor::listEnzymesInGroup (gr: %s, vs.GetCount: %lu)\n" , gr, vs.GetCount() ) ;
     if ( gr == txt("Current") )
         {
         if (!v)
@@ -319,12 +319,12 @@ void TRestrictionEditor::listEnzymesInGroup ( const wxString& gr , wxArrayString
         {
         myapp()->frame->LS->getEnzymesInGroup ( gr , vs ) ;
         }
-    wxPrintf( "D: TRestrictionEditor::listEnzymesInGroup (gr: %s, vs.GetCount: %lu)\n" , gr, vs.GetCount() ) ;
+    //wxPrintf( "D: TRestrictionEditor::listEnzymesInGroup (gr: %s, vs.GetCount: %lu)\n" , gr, vs.GetCount() ) ;
     }
 
 void TRestrictionEditor::pR_showGroupEnzymes ( const wxString& gr )
     {
-    wxPrintf( "D: TRestrictionEditor::pR_showGroupEnzymes(%s) - start\n" , gr ) ;
+    //wxPrintf( "D: TRestrictionEditor::pR_showGroupEnzymes(%s) - start\n" , gr ) ;
     el->DeleteAllItems() ;
     rsl->DeleteAllItems() ;
 
@@ -366,19 +366,19 @@ void TRestrictionEditor::pR_showGroupEnzymes ( const wxString& gr )
         el->SetFocus() ;
         pre = _T("") ;
         }
-    wxPrintf( "D: TRestrictionEditor::pR_showGroupEnzymes(%s) - end\n" , gr ) ;
+    //wxPrintf( "D: TRestrictionEditor::pR_showGroupEnzymes(%s) - end\n" , gr ) ;
     }
 
 wxArrayInt TRestrictionEditor::getcuts ( const wxString& enzyme )
     {
-    wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - start\n" , enzyme ) ;
+    //wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - start\n" , enzyme ) ;
     wxArrayInt ret ;
     { // block constraining use of variable j
     int j ;
     for ( j = 0 ; j < nocut.GetCount() && nocut[j] != enzyme ; j++ ) ;
     if ( j < nocut.GetCount() )
         {
-        wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret empty since known nocut\n" , enzyme ) ;
+        //wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret empty since known nocut\n" , enzyme ) ;
         return ret ; // No cuts, returning empty list
         }
     }
@@ -397,7 +397,7 @@ wxArrayInt TRestrictionEditor::getcuts ( const wxString& enzyme )
         TRestrictionEnzyme *e = myapp()->frame->LS->getRestrictionEnzyme ( enzyme );
         if ( e->getSequence().length() < 3 )
             {
-            wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret invalid sequence '%s' -> notcut\n" , enzyme , e->getSequence() ) ;
+            //wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret invalid sequence '%s' -> notcut\n" , enzyme , e->getSequence() ) ;
             return ret ;
             }
         else
@@ -407,18 +407,18 @@ wxArrayInt TRestrictionEditor::getcuts ( const wxString& enzyme )
             if ( x.size() == 0 ) // No cuts
                 {
                 nocut.Add ( enzyme ) ;
-                wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret notcut\n" , enzyme ) ;
+                //wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - ret notcut\n" , enzyme ) ;
                 return ret ;
                 }
             for ( int k = 0 ; k < x.size() ; k++ )
                 {
-                wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - adds cut at %d\n" , enzyme , x[k].getPos() ) ;
+                //wxPrintf ( "D: TRestrictionEditor::getcuts(%s) - adds cut at %d\n" , enzyme , x[k].getPos() ) ;
                 cutcache.push_back ( TREcache ( enzyme , x[k].getPos() ) ) ;
                 ret.Add ( x[k].getPos() ) ;
                 }
             }
         }
-    wxPrintf( "D: TRestrictionEditor::getcuts(%s) - end - Found %lu cuts\n" , enzyme , ret.GetCount()) ;
+    //wxPrintf( "D: TRestrictionEditor::getcuts(%s) - end - Found %lu cuts\n" , enzyme , ret.GetCount()) ;
     return ret ;
     }
 
@@ -441,16 +441,16 @@ void TRestrictionEditor::res_ll ( wxListEvent &event )
 
 void TRestrictionEditor::pR_showFragments ( int i )
     {
-    wxPrintf( "D: TRestrictionEditor::pR_showFragments(%d) - start\n" , i ) ;
+    //wxPrintf( "D: TRestrictionEditor::pR_showFragments(%d) - start\n" , i ) ;
     wxString enzyme = el->GetItemText ( i ) ;
     wxArrayInt vi = getcuts ( enzyme ) ;
     listFragments ( rsl , vi ) ;
-    wxPrintf( "D: TRestrictionEditor::pR_showFragments(%d) - end\n" , i ) ;
+    //wxPrintf( "D: TRestrictionEditor::pR_showFragments(%d) - end\n" , i ) ;
     }
 
 void TRestrictionEditor::getFragmentList ( wxArrayInt& cuts , vector <TFragment>& fragments , const bool clear ) const
     {
-    wxPrintf( "D: TRestrictionEditor::getFragmentList - start - cuts.GetCount=%d\n" , cuts.GetCount() ) ;
+    //wxPrintf( "D: TRestrictionEditor::getFragmentList - start - cuts.GetCount=%d\n" , cuts.GetCount() ) ;
 
     if (!v)
         {
@@ -483,12 +483,12 @@ void TRestrictionEditor::getFragmentList ( wxArrayInt& cuts , vector <TFragment>
         fr.length = len ;
         fragments.push_back ( fr ) ;
         }
-    wxPrintf( "D: TRestrictionEditor::getFragmentList - end\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::getFragmentList - end\n" ) ;
     }
 
 void TRestrictionEditor::listFragments ( wxListCtrl * const list , wxArrayInt &vi ) /* not const */
     {
-    wxPrintf( "D: TRestrictionEditor::listFragments - start\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::listFragments - start\n" ) ;
     if (!v)
         {
         wxPrintf( "E: TRestrictionEditor::listFragments - v is NULL\n" ) ;
@@ -535,12 +535,12 @@ void TRestrictionEditor::listFragments ( wxListCtrl * const list , wxArrayInt &v
         //sprintf ( u , "%d" , len ) ; // Length
         list->SetItem ( k , 3 , wxString::Format ( _T("%d") , len ) ) ;
         }
-    wxPrintf( "D: TRestrictionEditor::listFragments - end\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::listFragments - end\n" ) ;
     }
 
 void TRestrictionEditor::refreshCocktail () /* not const */
     {
-    wxPrintf( "D: TRestrictionEditor::refreshCocktail - start\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::refreshCocktail - start\n" ) ;
     wxArrayString vs = cocktail ;
     el2->DeleteAllItems() ;
     // char t[100] ;
@@ -571,12 +571,12 @@ void TRestrictionEditor::refreshCocktail () /* not const */
         }
     cocktailFragments = vi ; // not const
     listFragments ( rsl2 , vi ) ;
-    wxPrintf( "D: TRestrictionEditor::refreshCocktail - end\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::refreshCocktail - end\n" ) ;
     }
 
 void TRestrictionEditor::add2cocktail ( const wxString& s ) /* not const */
     {
-    wxPrintf( "D: TRestrictionEditor::add2cocktail(%s) - start\n" , s ) ;
+    //wxPrintf( "D: TRestrictionEditor::add2cocktail(%s) - start\n" , s ) ;
     if ( s.IsEmpty() )
         {
         wxPrintf( "D: TRestrictionEditor::add2cocktail(%s) - ret s empty\n" , s ) ;
@@ -595,15 +595,17 @@ void TRestrictionEditor::add2cocktail ( const wxString& s ) /* not const */
     cocktail.Add ( s ) ;
     cocktail.Sort() ;
     refreshCocktail () ;
-    wxPrintf( "D: TRestrictionEditor::add2cocktail(%s) - end\n" , s ) ;
+    //wxPrintf( "D: TRestrictionEditor::add2cocktail(%s) - end\n" , s ) ;
     }
 
 void TRestrictionEditor::del_from_cocktail ( const wxString& s ) /* not const */
     {
-    wxPrintf( "W: TRestrictionEditor::del_from_cocktail(%s) - start\n" , s ) ;
+    //wxPrintf( "W: TRestrictionEditor::del_from_cocktail(%s) - start\n" , s ) ;
     int i = 0 ;
     while ( i < cocktail.GetCount() && cocktail[i] != s )
+        {
         i++ ;
+        }
     if ( i == cocktail.GetCount() )
         {
         wxPrintf( "W: TRestrictionEditor::del_from_cocktail(%s) - ret enzyme not in cocktail\n" , s ) ;
@@ -611,7 +613,7 @@ void TRestrictionEditor::del_from_cocktail ( const wxString& s ) /* not const */
         }
     cocktail.RemoveAt ( i ) ;
     refreshCocktail () ;
-    wxPrintf( "W: TRestrictionEditor::del_from_cocktail(%s) - end\n" , s ) ;
+    //wxPrintf( "W: TRestrictionEditor::del_from_cocktail(%s) - end\n" , s ) ;
     }
 
 // "Restriction" handlers
@@ -699,7 +701,7 @@ void TRestrictionEditor::onAddAll ( wxCommandEvent &event )
 
 void TRestrictionEditor::iterateFragments ( const wxArrayInt& cuts , vector <TFragment> &fragments , const int depth ) const
     {
-    wxPrintf( "D: TRestrictionEditor::iterateFragments - end\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::iterateFragments - start\n" ) ;
     if ( cuts.size() == 0 ) return ;
     wxArrayInt cuts2 = cuts ;
     getFragmentList ( cuts2 , fragments , false ) ;
@@ -718,7 +720,10 @@ void TRestrictionEditor::iterateFragments ( const wxArrayInt& cuts , vector <TFr
 
     for ( int a = 1 ; a < fragments.size() ; a++ )
         {
-        if ( ! ( fragments[a-1] == fragments[a] ) ) continue ;
+        if ( ! ( fragments[a-1] == fragments[a] ) )
+            {
+            continue ;
+            }
         for ( int b = a ; b + 1 < fragments.size() ; b++ )
             {
             fragments[b] = fragments[b+1] ;
@@ -728,5 +733,5 @@ void TRestrictionEditor::iterateFragments ( const wxArrayInt& cuts , vector <TFr
         }
 
     global_sort_mode = gsm ;
-    wxPrintf( "D: TRestrictionEditor::iterateFragments - end\n" ) ;
+    //wxPrintf( "D: TRestrictionEditor::iterateFragments - end\n" ) ;
     }

--- a/src/TRestrictionEditor.h
+++ b/src/TRestrictionEditor.h
@@ -11,7 +11,8 @@ class wxNotebook ;
 class TRestrictionEnzyme ;
 
 /** \brief Restriction enzyme site cache
-*/
+ * In the context of a particular sequence, an object of this class remembers what enzyme cuts at which position.
+ */
 class TREcache
     {
     public :
@@ -21,7 +22,10 @@ class TREcache
     } ;
 
 /** \brief A restriction fragment (from, to, length)
-*/
+ * In the context of a particular sequence, this class brings together the specification of
+ * a subsequence, i.e. technically typically a fragment, and also knows the length and weight
+ * as derivative values beyond from and to.
+ */
 class TFragment
     {
     public :
@@ -33,7 +37,9 @@ bool operator < ( const TFragment &f1 , const TFragment &f2 ) ;
 bool operator == ( const TFragment &f1 , const TFragment &f2 ) ;
 
 /** \brief The restriction editor dialog class
-*/
+ * This class maintains the window from which the actual restriction is triggered in silico.
+ * Users select the enzymes to be applied together as a cocktail and press "Done".
+ */
 class TRestrictionEditor : public wxDialog
     {
     public :

--- a/src/TStorage.cpp
+++ b/src/TStorage.cpp
@@ -365,7 +365,7 @@ TSQLresult TStorage::getObjectSqlite2 ( const wxString &query )
 
 void TStorage::import ()
     {
-    wxPrintf( "TStorage::import - start\n" ) ;
+    //wxPrintf( "TStorage::import - start\n" ) ;
     // Importing restriction enzymes
     TSQLresult sr = getObject ( _T("SELECT * FROM enzyme") ) ;
     for ( int a = 0 ; a < sr.content.size() ; a++ )
@@ -403,10 +403,10 @@ void TStorage::import ()
                 wxPrintf( "E: TStorage::import - e->getSequence().IsEmpty() for %s\n" , e->getName() ) ;
                 }
             re.Add ( e ) ;
-            wxPrintf ( "D: TStorage::import: Imported '%s' with sequence '%s'\n" , e->getName() , e->getSequence() ) ;
+            //wxPrintf ( "D: TStorage::import: Imported '%s' with sequence '%s'\n" , e->getName() , e->getSequence() ) ;
             }
         }
-    wxPrintf( "TStorage::import - end\n" ) ;
+    //wxPrintf( "TStorage::import - end\n" ) ;
     }
 
 void TStorage::sqlAdd ( wxString &s1 , wxString &s2 , const wxString& key , const wxString& _value ) const
@@ -534,7 +534,7 @@ wxString TStorage::UCfirst ( const wxString& _s ) const
 */
 bool TStorage::copySQLfields ( TStorage &target , const wxString& table , const wxString& cond )
     {
-    wxPrintf( "D: TStorage::copySQLfields - start (table: %s, cond: %s)\n" , table , cond ) ;
+    //wxPrintf( "D: TStorage::copySQLfields - start (table: %s, cond: %s)\n" , table , cond ) ;
     wxString sql , s1 , s2 ;
     sql = _T("SELECT * FROM ") + table + _T(" WHERE ") + cond ;
     TSQLresult r = getObject ( sql ) ;
@@ -551,7 +551,7 @@ bool TStorage::copySQLfields ( TStorage &target , const wxString& table , const 
         target.getObject ( sql ) ;
         }
     return true ;
-    wxPrintf( "D: TStorage::copySQLfields - start (table: %s, cond: %s)\n" , table , cond ) ;
+    //wxPrintf( "D: TStorage::copySQLfields - start (table: %s, cond: %s)\n" , table , cond ) ;
     }
 
 
@@ -768,7 +768,7 @@ void TStorage::autoUpdateSchema ()
 // It synchronizes the enzyme lists between known databases
 void TStorage::synchronize ()
     {
-    wxPrintf( "D: TStorage::synchronize - start\n" ) ;
+    //wxPrintf( "D: TStorage::synchronize - start\n" ) ;
     bool changed ;
 
     // Sync only once a day
@@ -827,7 +827,7 @@ void TStorage::synchronize ()
                 }
            }
         } while ( changed ) ;
-    wxPrintf( "D: TStorage::synchronize - end\n" ) ;
+    //wxPrintf( "D: TStorage::synchronize - end\n" ) ;
     }
 
 wxString TStorage::makeInsert ( const wxString& table , const wxArrayString& field , const wxArrayString& data ) const
@@ -1029,7 +1029,7 @@ void TStorage::addRestrictionEnzyme ( TRestrictionEnzyme * const r )
 
 TRestrictionEnzyme* TStorage::getRestrictionEnzyme ( const wxString& s )
     {
-    wxPrintf( "D: TStorage::getRestrictionEnzyme (%s) - start\n" , s ) ;
+    //wxPrintf( "D: TStorage::getRestrictionEnzyme (%s) - start\n" , s ) ;
     TRestrictionEnzyme *ret = NULL , *ret2 ;
     if ( storagetype == TEMP_STORAGE )
         {
@@ -1074,18 +1074,18 @@ TRestrictionEnzyme* TStorage::getRestrictionEnzyme ( const wxString& s )
         ret = ret2 ;
         }
 
-    wxPrintf( "D: TStorage::getRestrictionEnzyme (%s) - end\n" ) ;
+    //wxPrintf( "D: TStorage::getRestrictionEnzyme (%s) - end\n" , s ) ;
     return ret ;
     }
 
 void TStorage::getEnzymesInGroup ( const wxString& _gn , wxArrayString &vs )
     {
-    wxPrintf( "D: TStorage::getEnzymesInGroup - start (%s)\n" , _gn ) ;
+    //wxPrintf( "D: TStorage::getEnzymesInGroup - start (%s)\n" , _gn ) ;
     TStorage *t = getDBfromEnzymeGroup ( _gn ) ;
     if ( t )
         {
         wxString tstripped = stripGroupName ( _gn ) ;
-        wxPrintf( "D: TStorage::getEnzymesInGroup - ret found DB getDBfromEnzymeGroup (%s)\n" , _gn ) ;
+        wxPrintf( "D: TStorage::getEnzymesInGroup(%s) - ret found DB getDBfromEnzymeGroup (%s)\n" , _gn , tstripped) ;
         t->getEnzymesInGroup ( tstripped , vs ) ;
         return ;
         }
@@ -1093,7 +1093,11 @@ void TStorage::getEnzymesInGroup ( const wxString& _gn , wxArrayString &vs )
     if ( !isLocalDB() ) // Use cache
         {
         getEnzymeCache ( _gn , vs ) ;
-        if ( vs.GetCount() ) return ;
+        if ( vs.GetCount() )
+            {
+            wxPrintf( "D: TStorage::getEnzymesInGroup(%s) - ret !isLocalDB & getEnzymeCache was successful\n" , _gn ) ;
+            return ;
+            }
         }
 
     vs.Clear() ;
@@ -1124,16 +1128,25 @@ void TStorage::getEnzymesInGroup ( const wxString& _gn , wxArrayString &vs )
             }
         }
 
-    for ( int a = 0 ; a < vs.GetCount() ; a++ )
+    int a = 0 ;
+    while ( a < vs.GetCount() )
         {
         if ( vs[a].IsEmpty() )
-           {
-           vs.RemoveAt ( a ) ;
-           a-- ;
-           }
+            {
+            wxPrintf( "D: TStorage::getEnzymesInGroup: Removing empty enzyme\n" ) ;
+            vs.RemoveAt ( a ) ;
+            }
+        else
+            {
+            a++ ;
+            }
         }
 
-    if ( !isLocalDB() ) setEnzymeCache ( gn , vs ) ;
+
+    if ( !isLocalDB() )
+        {
+        setEnzymeCache ( gn , vs ) ;
+        }
     }
 
 void TStorage::getEnzymeGroups ( wxArrayString &vs )
@@ -1143,33 +1156,54 @@ void TStorage::getEnzymeGroups ( wxArrayString &vs )
     if ( t && isLocalDB() && t != this )
         {
         t->getEnzymeGroups ( vs ) ;
+        wxPrintf( "D: TStorage::getEnzymeGroups: Seeding with local groups:" ) ;
         for ( int a = 0 ; a < vs.GetCount() ; a++ )
+            {
             vs[a] = defdb + _T(":") + vs[a] ;
+            wxPrintf( " %s" , vs[a] ) ;
+            }
+        wxPrintf( "\n" ) ;
         }
-    else vs.Clear() ;
+    else
+        {
+        wxPrintf( "D: TStorage::getEnzymeGroups: Nothing from local groups.\n" ) ;
+        vs.Clear() ;
+        }
 
     if ( !isLocalDB() && enzymeGroupNameCache.GetCount() ) // Use cache
         {
+        wxPrintf( "D: TStorage::getEnzymeGroups: Returning with the following extra enzyme groups:" ) ;
         for ( int a = 0 ; a < enzymeGroupNameCache.GetCount() ; a++ )
             {
+            wxPrintf( " %s" , enzymeGroupNameCache[a] ) ;
             vs.Add ( enzymeGroupNameCache[a] ) ;
             }
+        wxPrintf( "\n" ) ;
         return ;
         }
 
-    if ( !isLocalDB() ) cleanEnzymeGroupCache () ;
+    if ( !isLocalDB() )
+        {
+        wxPrintf( "D: TStorage::getEnzymeGroups: Cleaning enzyme group cache.\n" ) ;
+        vs.Clear() ;
+        cleanEnzymeGroupCache () ;
+        }
+
+    wxPrintf( "D: TStorage::getEnzymeGroups: Retrieving via SQL query:" ) ;
     wxString sql = "SELECT eg_name FROM enzyme_group" ;
     TSQLresult sr = getObject ( sql ) ;
     for ( int a = 0 ; a < sr.content.size() ; a++ )
         {
         wxString groupname = UCfirst ( sr[a][sr["eg_name"]] ) ;
         vs.Add ( groupname ) ;
+        wxPrintf( " %s" , groupname ) ;
         if ( !isLocalDB() )
             {
             enzymeGroupNameCache.Add ( groupname ) ; // Add to cache
             enzymeGroupCache.Add ( _T("") ) ; // Add blank dummy to cache
             }
         }
+    wxPrintf( "\n" ) ;
     }
 
 void TStorage::updateRestrictionEnzyme ( /* not const*/ TRestrictionEnzyme * const e ) /* not const */
@@ -1255,7 +1289,7 @@ TStorage* TStorage::getDBfromEnzymeGroup ( const wxString& group )
     wxString s = group.BeforeLast ( ':' ) ;
     if ( s.IsEmpty() )
         {
-        wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> NULL - no colon\n" , group ) ;
+        //wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> NULL - no colon\n" , group ) ;
         return NULL ;
         }
 
@@ -1265,11 +1299,11 @@ TStorage* TStorage::getDBfromEnzymeGroup ( const wxString& group )
         {
         if ( db_name[a] == s )
             {
-            wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> found database '%s'\n" , group  , s ) ;
+            //wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> found database '%s'\n" , group  , s ) ;
             return myapp()->frame->getTempDB ( db_file[a] ) ;
             }
         }
-    wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> no database or not colon found\n" , group  , s ) ;
+    //wxPrintf( "D: TStorage::getDBfromEnzymeGroup(%s) -> no database or not colon found\n" , group  , s ) ;
     return NULL ;
     }
 
@@ -1281,7 +1315,7 @@ TStorage* TStorage::getDBfromEnzymeGroup ( const wxString& group )
 wxString TStorage::stripGroupName ( const wxString& enzyme ) const
     {
     wxString s = enzyme.AfterLast ( ':' )  ;
-    wxPrintf( "D: TStorage::stripGroupName: '%s' -> '%s'\n" , enzyme , s ) ;
+    //wxPrintf( "D: TStorage::stripGroupName: '%s' -> '%s'\n" , enzyme , s ) ;
     return UCfirst ( s ) ;
     }
 
@@ -1394,13 +1428,13 @@ bool TStorage::convertSqlite2to3 ()
 
 void TStorage::syncEnzymes ( TStorage* to )
     {
-    wxPrintf( "D: TStorage::syncEnzymes - start\n" ) ;
+    //wxPrintf( "D: TStorage::syncEnzymes - start\n" ) ;
     bool useBlank = false ;
     if ( to == NULL )
         {
         wxString dbPath = myapp()->homedir.GetFullPath() + wxFileName::GetPathSeparator() + "blank.db" ;
         to = new TStorage ( TEMP_STORAGE , dbPath ) ;
-        wxPrintf( "D: TStorage::syncEnzymes - creating new blank storage.\n" ) ;
+        wxPrintf( "I: TStorage::syncEnzymes - creating new blank storage.\n" ) ;
         useBlank = true ;
         }
 
@@ -1438,5 +1472,5 @@ void TStorage::syncEnzymes ( TStorage* to )
     endRecord() ;
 
     if ( useBlank ) delete to ;
-    wxPrintf( "D: TStorage::syncEnzymes - end\n" ) ;
+    //wxPrintf( "D: TStorage::syncEnzymes - end\n" ) ;
     }

--- a/src/TVector.cpp
+++ b/src/TVector.cpp
@@ -971,32 +971,38 @@ void TVector::recalculateCuts ()
 // Returns wether or not "equal" enzymes should be joined
 bool TVector::getVectorCuts ()
     {
-    wxPrintf( "D: TVector::getVectorCuts - start\n" ) ;
+    //wxPrintf( "D: TVector::getVectorCuts - start\n" ) ;
     TEnzymeRules *er = getEnzymeRule () ;
     er->getVectorCuts ( this ) ;
-    wxPrintf( "D: TVector::getVectorCuts - end - returning %d\n" , er->join_enzymes ) ;
+    //wxPrintf( "D: TVector::getVectorCuts - end - returning %d\n" , er->join_enzymes ) ;
     return er->join_enzymes ;
     }
 
 // Gets the enzyme rules to follow
 TEnzymeRules* TVector::getEnzymeRule () const
     {
-    wxPrintf( "D: TVector::getEnzymeRule - start\n" ) ;
+    //wxPrintf( "D: TVector::getEnzymeRule - start\n" ) ;
     TEnzymeRules *er ;
     if ( enzyme_rules ) // Vector settings
         {
         er = enzyme_rules ;
-        if ( er->useit ) return er ;
+        if ( er->useit )
+            {
+            return er ;
+            }
         }
 
     if ( myapp()->frame->project.getEnzymeRules() ) // Project settings
         {
         er = myapp()->frame->project.getEnzymeRules() ;
-        if ( er->useit ) return er ;
+        if ( er->useit )
+            {
+            return er ;
+            }
         }
 
     er = myapp()->frame->global_enzyme_rules ; // Global settings
-    wxPrintf( "D: TVector::getEnzymeRule - end\n" ) ;
+    //wxPrintf( "D: TVector::getEnzymeRule - end\n" ) ;
     return er ;
     }
 
@@ -1137,7 +1143,7 @@ wxString TVector::transformSequence ( const wxString& sequence, const bool inver
 
 void TVector::doRestriction ()
     {
-    wxPrintf( "D: TVector::doRestriction - start\n" ) ;
+    //wxPrintf( "D: TVector::doRestriction - start\n" ) ;
     vector <TRestrictionCut> cl ;
 
     mylog ( "TVector::doRestriction" , "1" ) ;
@@ -1245,7 +1251,7 @@ void TVector::doRestriction ()
     cocktail.Clear() ;
     mylog ( "TVector::doRestriction" , "10" ) ;
     updateDisplay ( true ) ;
-    wxPrintf( "D: TVector::doRestriction - end\n" ) ;
+    //wxPrintf( "D: TVector::doRestriction - end\n" ) ;
     }
 
 void TVector::doAction ()
@@ -1461,36 +1467,36 @@ wxString TVector::dna2aa ( const wxString& codon , const int translation_table )
     if ( c1 == ' ' ) return _T("?") ;
     if ( c2 == ' ' ) return _T("?") ;
     if ( ACGT[c0] != ' ' && ACGT[c1] != ' ' && ACGT[c2] != ' ' )
-       {
-       int i = ACGT[c0]*16 +
-               ACGT[c1]*4 +
-               ACGT[c2] ;
-       if ( i > 63 ) r = _T("?") ;
-       else r = aa.GetChar(i) ;
+        {
+        int i = ACGT[c0]*16 +
+                ACGT[c1]*4 +
+                ACGT[c2] ;
+        if ( i > 63 ) r = _T("?") ;
+        else r = aa.GetChar(i) ;
        }
     else
-       {
-       char u = ' ' ;
-       wxString s0 = TVector::vary_base ( c0 ) ;
-       wxString s1 = TVector::vary_base ( c1 ) ;
-       wxString s2 = TVector::vary_base ( c2 ) ;
-       for ( int a0 = 0 ; a0 < s0.length() ; a0++ )
-           for ( int a1 = 0 ; a1 < s1.length() ; a1++ )
-               for ( int a2 = 0 ; a2 < s2.length() ; a2++ )
-                   {
-                   char v ;
-                   int i = ACGT[s0.GetChar(a0)]*16 +
-                           ACGT[s1.GetChar(a1)]*4 +
-                           ACGT[s2.GetChar(a2)] ;
-                   if ( i > 63 ) v = '?' ;
-                   else v = aa.GetChar(i) ;
-                   if ( u != ' ' && u != v ) return _T("?") ;
-                   else if ( v == '?' ) return _T("?") ;
-                   else u = v ;
-                   }
-       if ( u == ' ' ) r = _T("?") ;
-       else r = (wxChar) u ;
-       }
+        {
+        char u = ' ' ;
+        wxString s0 = TVector::vary_base ( c0 ) ;
+        wxString s1 = TVector::vary_base ( c1 ) ;
+        wxString s2 = TVector::vary_base ( c2 ) ;
+        for ( int a0 = 0 ; a0 < s0.length() ; a0++ )
+            for ( int a1 = 0 ; a1 < s1.length() ; a1++ )
+                for ( int a2 = 0 ; a2 < s2.length() ; a2++ )
+                    {
+                    char v ;
+                    int i = ACGT[s0.GetChar(a0)]*16 +
+                            ACGT[s1.GetChar(a1)]*4 +
+                            ACGT[s2.GetChar(a2)] ;
+                    if ( i > 63 ) v = '?' ;
+                    else v = aa.GetChar(i) ;
+                    if ( u != ' ' && u != v ) return _T("?") ;
+                    else if ( v == '?' ) return _T("?") ;
+                    else u = v ;
+                    }
+        if ( u == ' ' ) r = _T("?") ;
+        else r = (wxChar) u ;
+        }
     return r ;
     }
 
@@ -1530,12 +1536,21 @@ void TVector::turn ( const int off )
     turned += off ;
     }
 
+/** \brief Determines number of cuts a given enzyme has on this vector's sequence
+ * The vector's rc list of cuts is iterated for cuts that have the exact same enzyme name.
+ * @param enzyme - name of enzyme to find in this vector's cuts list (rc)
+ * @returns - number of cuts by that enzyme
+ */
 int TVector::countCuts ( const wxString& enzyme ) const
     {
     int count = 0 ;
     for ( int a = 0 ; a < rc.size() ; a++ )
+        {
         if ( rc[a].e->getName() == enzyme )
-           count++ ;
+            {
+            count++ ;
+            }
+        }
     return count ;
     }
 
@@ -1674,10 +1689,17 @@ TVector *TVector::getAAvector ( const int _from , const int _to , const int dir 
     aas.initFromTVector ( v ) ;
     mylog ( "TVector::getAAvector" , "1" ) ;
     v->sequence = aas.s ;
-    for ( int a = to+1 ; a < v->sequence.length() ; a++ ) v->sequence.SetChar(a,UNIQUE) ;
+    for ( int a = to+1 ; a < v->sequence.length() ; a++ )
+        {
+        v->sequence.SetChar(a,UNIQUE) ;
+        }
     for ( int a = 0 ; a < v->sequence.length() ; a++ )
+        {
         if ( v->sequence.GetChar(a) == ' ' || v->sequence.GetChar(a) == '|' )
-           v->sequence.SetChar(a,UNIQUE) ;
+            {
+            v->sequence.SetChar(a,UNIQUE) ;
+            }
+        }
 
 
     mylog ( "TVector::getAAvector" , "2" ) ;
@@ -1689,15 +1711,22 @@ TVector *TVector::getAAvector ( const int _from , const int _to , const int dir 
 //    wxStopWatch sw ;
 //    sw.Start() ;
     // Removing non-AA sequence and features
-    for ( int a = 0 ; a < v->sequence.length() ; a++ )
+    int a = 0 ;
+    while ( a < v->sequence.length() )
         {
         if ( v->sequence.GetChar(a) == UNIQUE )
-           {
-           int b;
-           for ( b = a+1 ; b < v->sequence.length() && v->sequence.GetChar(b) == UNIQUE ; b++ ) ;
-           v->doRemove ( a+1 , b , false , false ) ;
-           a-- ;
-           }
+            {
+            int b = a + 1;
+            while ( b < v->sequence.length() && v->sequence.GetChar(b) == UNIQUE )
+                {
+                b++ ;
+                }
+            v->doRemove ( a+1 , b , false , false ) ;
+            }
+        else
+            {
+            a++ ;
+            }
         }
     mylog ( "TVector::getAAvector" , "4" ) ;
 
@@ -1708,18 +1737,21 @@ TVector *TVector::getAAvector ( const int _from , const int _to , const int dir 
     if ( dir < 0 )
         {
         wxString t ;
-        for ( int a = 0 ; a < v->sequence.length() ; a++ ) t = v->sequence.GetChar(a) + t ;
+        for ( int a = 0 ; a < v->sequence.length() ; a++ )
+            {
+            t = v->sequence.GetChar(a) + t ;
+            }
         v->sequence = t ;
         for ( int a = 0 ; a < v->items.size() ; a++ )
-           {
-           int f = v->sequence.length() - v->items[a].to + 1 ;
-           v->items[a].to = v->sequence.length() - v->items[a].from + 1 ;
-           v->items[a].from = f ;
-           }
+            {
+            int f = v->sequence.length() - v->items[a].to + 1 ;
+            v->items[a].to = v->sequence.length() - v->items[a].from + 1 ;
+            v->items[a].from = f ;
+            }
         }
 
     v->circular = false ;
-//    wxMessageBox ( wxString::Format ( "%d ms" , sw.Time() ) ) ;
+//  wxMessageBox ( wxString::Format ( "%d ms" , sw.Time() ) ) ;
     mylog ( "TVector::getAAvector" , "5" ) ;
     return v ;
     }
@@ -1730,7 +1762,6 @@ void TVector::callUpdateUndoMenu ()
     window->updateUndoMenu() ;
     }
 
-
 /* deprecated - need to revisit all invocations ... */
 void TVector::setFromVector ( const TVector& v )
     {
@@ -1739,9 +1770,16 @@ void TVector::setFromVector ( const TVector& v )
     undo.clear () ;
     }
 
+/** \brief Returns length of item (feature)
+ * @param itemno - The position of the item in the items array
+ * @returns The number of nucleotides/residues constituting the item
+ */
 int TVector::getItemLength ( const int itemno ) const
     {
-    if ( items[itemno].to >= items[itemno].from ) return items[itemno].to - items[itemno].from + 1 ;
+    if ( items[itemno].to >= items[itemno].from )
+        {
+        return items[itemno].to - items[itemno].from + 1 ;
+        }
     return items[itemno].to + sequence.length() - items[itemno].from + 1 ;
     }
 
@@ -1771,6 +1809,10 @@ void TVector::clear ()
     proteases.Clear () ;
     }
 
+/** \brief Returns position of item with a given name
+ * @param s - Name of item to be found
+ * @returns - Position of item in items array, -1 if not found
+ */
 int TVector::find_item ( const wxString& s ) const
     {
     for ( int a = 0 ; a < items.size() ; a++ )
@@ -1799,6 +1841,11 @@ void TVector::hideEnzyme ( const wxString& s , const bool hideit )
         }
     }
 
+/** \brief sorts list of cuts
+ * The restriction cuts of this vector stored in the rc array, but are initially
+ * ordered by the enzymes, which is not helpful, e.g., to derive the fragments of cocktails.
+ * This routine sorts the cuts by their position.
+ */
 void TVector::sortRestrictionSites ()
     {
     for ( int a = 1 ; a < rc.size() ; a++ ) // Sort by pos
@@ -1918,13 +1965,13 @@ TVector *TVector::backtranslate ( const wxString& mode ) // not const becaues of
     nv->type = TYPE_VECTOR ;
     wxString ns ;
     TVector::makeAA2DNA ( nv, mode ) ;
-    for ( int a = 0 ; a < nv -> sequence.length() ; a++ )
+    for ( unsigned int a = 0 ; a < nv -> sequence.length() ; a++ )
         {
         unsigned char c = sequence.GetChar ( a ) ;
         ns += nv->AA2DNA[c] ;
         }
     nv->sequence = ns ;
-    for ( int a = 0 ; a < nv->items.size() ; a++ )
+    for ( unsigned int a = 0 ; a < nv->items.size() ; a++ )
        {
        nv->items[a].from = ( nv->items[a].from - 1 ) * 3 + 1 ;
        nv->items[a].to = ( nv->items[a].to - 1 ) * 3 + 1 ;
@@ -1935,7 +1982,7 @@ TVector *TVector::backtranslate ( const wxString& mode ) // not const becaues of
 int TVector::getMem () const
     {
     int r = 0 ;
-    for ( int a = 0 ; a < items.size() ; a++ ) r += items[a].getMem() ;
+    for ( unsigned int a = 0 ; a < items.size() ; a++ ) r += items[a].getMem() ;
     r += sizeof ( TVector ) ;
     r += sizeof ( TORF ) * worf.size () ;
     r += rc.size() * sizeof ( TRestrictionCut ) ;
@@ -1952,13 +1999,13 @@ void TVector::addRestrictionEnzyme ( TRestrictionEnzyme * const e )
     {
     if ( e->getName().IsEmpty() )
         {
-        wxPrintf( "D: TVector::addRestrictionEnzyme - attempt to add enzyme with empty name\n" ) ;
+        wxPrintf( "E: TVector::addRestrictionEnzyme - attempt to add enzyme with empty name\n" ) ;
         abort() ;
         }
 
     if ( e->getSequence().IsEmpty() )
         {
-        wxPrintf( "D: TVector::addRestrictionEnzyme - attempt to add enzyme %s with empty sequence\n" , e->getName() ) ;
+        wxPrintf( "E: TVector::addRestrictionEnzyme - attempt to add enzyme %s with empty sequence\n" , e->getName() ) ;
         abort() ;
         }
 
@@ -2088,8 +2135,10 @@ wxString TVectorItem::implodeParams () const
         {
         wxString t = pvalue[a] ;
         for ( int b = 0 ; b < t.length() ; b++ )
-           if ( t.GetChar(b) == '\n' )
-              t.SetChar ( b , 2 ) ;
+            {
+            if ( t.GetChar(b) == '\n' )
+                t.SetChar ( b , 2 ) ;
+            }
         s += pname[a] ;
         s += _T("\n") + t + _T("\n") ;
         }
@@ -2109,8 +2158,12 @@ void TVectorItem::explodeParams ( const wxString& _s )
         for ( int a = 0 ; s.GetChar(a) != '\n' ; a++ ) ; // proceed until end of line
         wxString v = s.substr ( 0 , a ) ;
         for ( int a = 0 ; a < v.length() ; a++ )
+            {
             if ( v.GetChar(a) == 2 )
+                {
                 v.SetChar ( a , '\n' ) ;
+                }
+            }
         s = s.substr ( a + 1 ) ;
         setParam ( n , v ) ;
         }
@@ -2396,13 +2449,13 @@ void TVectorItem::getArrangedAA ( const TVector * const vectorToTranslate , wxSt
 
     if ( ! v )
         {
-        wxPrintf( "TVectorItem::getArrangedAA - !v\n" ) ;
+        wxPrintf( "D: TVectorItem::getArrangedAA - !v\n" ) ;
         abort() ;
         }
 
     if ( ! aa )
         {
-        wxPrintf( "TVectorItem::getArrangedAA - !aa\n" ) ;
+        wxPrintf( "D: TVectorItem::getArrangedAA - !aa\n" ) ;
         abort() ;
         }
 
@@ -2425,12 +2478,12 @@ void TVectorItem::getArrangedAA ( const TVector * const vectorToTranslate , wxSt
         {
         if (!(*dna2aa)[a].dna[0])
             {
-            wxPrintf( "TVectorItem::getArrangedAA - !(*dna2aa)[%d].dna\n" , a ) ;
+            wxPrintf( "D: TVectorItem::getArrangedAA - !(*dna2aa)[%d].dna\n" , a ) ;
             abort() ;
             }
         if (!(*dna2aa)[a].aa)
             {
-            wxPrintf( "TVectorItem::getArrangedAA - !(*dna2aa)[%d].aa\n" , a ) ;
+            wxPrintf( "D: TVectorItem::getArrangedAA - !(*dna2aa)[%d].aa\n" , a ) ;
             abort() ;
             }
         if ( disp == AA_ONE )
@@ -2442,11 +2495,11 @@ void TVectorItem::getArrangedAA ( const TVector * const vectorToTranslate , wxSt
             }
         else
             {
-            wxPrintf( "TVectorItem::getArrangedAA - else\n" ) ;
+            //wxPrintf( "D: TVectorItem::getArrangedAA - else\n" ) ;
             int one = (int)(*dna2aa)[a].aa ;
-            wxPrintf( "TVectorItem::getArrangedAA - (int)(*dna2aa)[%d].aa = %d\n" , a , one ) ;
+            //wxPrintf( "D: TVectorItem::getArrangedAA - (int)(*dna2aa)[%d].aa = %d\n" , a , one ) ;
             wxString three = v->one2three( one ) ;
-            wxPrintf( "TVectorItem::getArrangedAA - three = %s\n" , three ) ;
+            //wxPrintf( "D: TVectorItem::getArrangedAA - three = %s\n" , three ) ;
             for( int i = 0; i < 3 ; i++)
                 {
                 wxChar c = three.GetChar(i) ;
@@ -2465,7 +2518,9 @@ int TVectorItem::getOffsetAt ( const int i ) const
     for ( int a = 0 ; a < dna2aa_item.size() ; a++ )
         {
         if ( dna2aa_item[a].dna[0] == i )
+            {
             return a + getOffset() ;
+            }
         }
     return -1 ;
     }
@@ -2579,7 +2634,6 @@ TORF::TORF ()
     {
     rf = 0 ;
     } ;
-
 
 TORF::TORF ( const int _f , const int _t , const int _r )
     {

--- a/src/TVectorEditor.cpp
+++ b/src/TVectorEditor.cpp
@@ -41,6 +41,8 @@ BEGIN_EVENT_TABLE(TVectorEditor, wxDialog )
     EVT_CHAR_HOOK(TVectorEditor::OnCharHook)
 END_EVENT_TABLE()
 
+wxArrayString TVectorEditor::ce ;
+
 void TVectorEditor::OnCharHook(wxKeyEvent& event)
     {
     int k = event.GetKeyCode () ;
@@ -53,7 +55,7 @@ void TVectorEditor::OnCharHook(wxKeyEvent& event)
 TVectorEditor::TVectorEditor(wxWindow *parent, const wxString& title , TVector *_v )
          : wxDialog ( parent , -1 , title , wxDefaultPosition , wxSize ( 620 , 550 ) )
     {
-    wxPrintf("TVectorEditor::TVectorEditor - start\n");
+    wxPrintf( "D: TVectorEditor::TVectorEditor - start\n" ) ;
     myapp()->frame->push_help ( _T("GENtle:Sequence_editor") ) ;
     lastSelection = -1 ;
     v = _v ;
@@ -82,7 +84,7 @@ TVectorEditor::TVectorEditor(wxWindow *parent, const wxString& title , TVector *
     if ( v ) name->SetFocus() ;
     addOkCancel ( this ) ;
     Center () ;
-    wxPrintf("TVectorEditor::TVectorEditor - end\n");
+    wxPrintf( "D: TVectorEditor::TVectorEditor - end\n" ) ;
     }
 
 TVectorEditor::~TVectorEditor ()
@@ -118,8 +120,8 @@ void TVectorEditor::initPanProt ()
 
     wxRect r = b->GetRect() ;
     pro_txt = new TURLtext ( panProt , URLTEXT_DUMMY , _T("") , wxPoint ( r.GetRight() + bo , r.GetTop() ) ,
-                                wxSize ( w - th - bo - r.GetRight() , h - th*2 - r.GetTop() ) ,
-                                wxTE_MULTILINE|wxTE_READONLY ) ;
+                             wxSize ( w - th - bo - r.GetRight() , h - th*2 - r.GetTop() ) ,
+                             wxTE_MULTILINE|wxTE_READONLY ) ;
     pro_txt->SetBackgroundColour ( wxSystemSettings::GetColour ( wxSYS_COLOUR_BTNFACE ) ) ;
 
 //    addOkCancel ( panProt ) ;
@@ -165,12 +167,10 @@ void TVectorEditor::initPanProp ()
         {
         // Sticky ends
         r = (new wxStaticText(panProp,-1,_T("5'-"),wxPoint(bo,th*8)))->GetRect() ;
-        lu = new wxTextCtrl(panProp,-1,v->getStickyEnd(true,true),
-                                wxPoint(r.GetRight()+bo,r.GetTop()-bo),wxSize(w/5,th));
+        lu = new wxTextCtrl(panProp,-1,v->getStickyEnd(true,true), wxPoint(r.GetRight()+bo,r.GetTop()-bo),wxSize(w/5,th));
 
         r = (new wxStaticText(panProp,-1,_T("-3'"),wxPoint(w-r.GetRight(),r.GetTop())))->GetRect() ;
-        ru = new wxTextCtrl(panProp,-1,v->getStickyEnd(false,true),
-                                wxPoint(r.GetLeft()-bo-w/5,r.GetTop()-bo),wxSize(w/5,th));
+        ru = new wxTextCtrl(panProp,-1,v->getStickyEnd(false,true), wxPoint(r.GetLeft()-bo-w/5,r.GetTop()-bo),wxSize(w/5,th));
 
         wxString k ;
         while ( k.length() * (r.GetWidth()/3) < w/2 )
@@ -180,12 +180,10 @@ void TVectorEditor::initPanProp ()
         new wxStaticText(panProp,-1,k,wxPoint(lu->GetRect().GetRight()+bo,r.GetTop())) ;
 
         r = (new wxStaticText(panProp,-1,_T("3'-"),wxPoint(bo,r.GetBottom()+th)))->GetRect() ;
-        ll = new wxTextCtrl(panProp,-1,v->getStickyEnd(true,false),
-                                wxPoint(r.GetRight()+bo,r.GetTop()-bo),wxSize(w/5,th));
+        ll = new wxTextCtrl(panProp,-1,v->getStickyEnd(true,false), wxPoint(r.GetRight()+bo,r.GetTop()-bo),wxSize(w/5,th));
 
         r = (new wxStaticText(panProp,-1,_T("-5'"),wxPoint(w-r.GetRight(),r.GetTop())))->GetRect() ;
-        rl = new wxTextCtrl(panProp,-1,v->getStickyEnd(false,false),
-                                wxPoint(r.GetLeft()-bo-w/5,r.GetTop()-bo),wxSize(w/5,th));
+        rl = new wxTextCtrl(panProp,-1,v->getStickyEnd(false,false), wxPoint(r.GetLeft()-bo-w/5,r.GetTop()-bo),wxSize(w/5,th));
 
         new wxStaticText(panProp,-1,k,wxPoint(lu->GetRect().GetRight()+bo,r.GetTop())) ;
         }
@@ -283,12 +281,13 @@ void TVectorEditor::commitEnzymes ()
     for ( int a = 0 ; a < v->re.GetCount() ; a++ )
         {
         int b = 0 ;
-        while ( b < ce.GetCount() && ce[b] != v->re[a]->getName() )
+        while ( b < TVectorEditor::ce.GetCount() && TVectorEditor::ce[b] != v->re[a]->getName() )
             {
             b++ ;
             }
-        if ( b == ce.GetCount() )
+        if ( b == TVectorEditor::ce.GetCount() )
             {
+            // Enzyme in re is not in ce, so it must have been removed in ce, so we remove it from re now
             changed = true ;
             v->re.RemoveAt ( a ) ;
             a-- ;
@@ -296,15 +295,16 @@ void TVectorEditor::commitEnzymes ()
         }
 
     // Added enzymes
-    for ( int b = 0 ; b < ce.GetCount() ; b++ )
+    for ( int b = 0 ; b < TVectorEditor::ce.GetCount() ; b++ )
         {
         int a ;
-        for ( a = 0 ; a < v->re.GetCount() && ce[b] != v->re[a]->getName() ; a++ )
+        for ( a = 0 ; a < v->re.GetCount() && TVectorEditor::ce[b] != v->re[a]->getName() ; a++ )
             ;
         if ( a == v->re.GetCount() )
             {
+            // Enzyme in ce is not in re, so it must have been added to ce, so we also add it to re
             changed = true ;
-            v->re.Add ( myapp()->frame->LS->getRestrictionEnzyme ( ce[b] )  ) ;
+            v->re.Add ( myapp()->frame->LS->getRestrictionEnzyme ( TVectorEditor::ce[b] )  ) ;
             }
         }
 

--- a/src/TVectorEditor.h
+++ b/src/TVectorEditor.h
@@ -16,8 +16,10 @@ class TURLtext ;
 class TEnzymeSettingsTab ;
 class TEnzymeRules ;
 
-/** \brief The sequence edit dialog
-*/
+/** \brief The enzyme management dialog
+ * Opened as a modal box to update the list of known enzymes and specify subgroups of enzymes of interest
+ * that can then be summoned in another dialog box for sequence-specific contexts.
+ */
 class TVectorEditor : public wxDialog
     {
     public :
@@ -83,6 +85,9 @@ class TVectorEditor : public wxDialog
 
     bool hideProp , hideItem , hideEnzym ;
 
+    protected:
+    static wxArrayString ce ; ///< Holds current enzymes
+
     private :
     virtual int getCurrentItem () const ; ///< Returns the ID of the currently selected item
     virtual void clearItemSelection () ; ///< Clears the current item selection
@@ -91,7 +96,7 @@ class TVectorEditor : public wxDialog
 
     wxListBox *listCE , *listGroups , *listGE ;
     wxArrayString eig ;
-    wxArrayString ce ; ///< Holds current enzymes
+
 
     TVector *v ;
     int bo , th ;

--- a/src/TVectorEditorEnzymes.cpp
+++ b/src/TVectorEditorEnzymes.cpp
@@ -87,7 +87,16 @@ void TVectorEditor::initPanEnzym ()
     listGroups->Clear() ;
     showEnzymeGroups () ;
 
-    ce.Clear() ;
+    wxPrintf( "I: Before clearing ce, ce contains:\n" ) ;
+    debugStdout("ce") ;
+    for ( int a = 0 ; a < TVectorEditor::ce.GetCount() ; a++ )
+        {
+        wxString s = TVectorEditor::ce[a] ;
+        wxPrintf( "D: TVectorEditor::initPanEnzym - Adding '%s' from ce list to widget\n" , s ) ;
+        listCE->Append ( s ) ;
+        }
+
+    //TVectorEditor::ce.Clear() ; // not loosing previously used settings in "current" list
     for ( int a = 0 ; v && a < v->re.GetCount() ; a++ )
         {
         wxString s = v->re[a]->getName() ;
@@ -96,8 +105,19 @@ void TVectorEditor::initPanEnzym ()
             wxPrintf( "E: TVectorEditor::initPanEnzym - enzyme %s = re[%d]->getSequence.IsEmpty()\n" , v->re[a]->getName(), a ) ;
             abort() ;
             }
-        listCE->Append ( s ) ;
-        ce.Add ( s ) ;
+        int foundInCE=0 ;
+        for(int a = 0; a < TVectorEditor::ce.GetCount() ; a++ )
+            {
+            if (s == ce[a] )
+                {
+                foundInCE = 1 ;
+                }
+            }
+        if ( ! foundInCE )
+            {
+            listCE->Append ( s ) ;
+            TVectorEditor::ce.Add ( s ) ;
+            }
         }
 
     debugStdout("ce") ;
@@ -111,9 +131,9 @@ void TVectorEditor::initPanEnzym ()
 void TVectorEditor::debugStdout(const wxString &whatToPrint ) const
     {
     wxPrintf( "D: TVectorEditor::debugStdout - ce: " );
-    for( int a = 0 ; a < ce.GetCount() ; a++ )
+    for( int a = 0 ; a < TVectorEditor::ce.GetCount() ; a++ )
         {
-        wxPrintf( " %s" , ce[a] ) ;
+        wxPrintf( " %s" , TVectorEditor::ce[a] ) ;
         }
     wxPrintf( "\n" );
     }
@@ -196,6 +216,7 @@ void TVectorEditor::showEnzymeGroups ()
     myapp()->frame->LS->getEnzymeGroups ( vs ) ;
     for ( int i = 0 ; i < vs.GetCount() ; i++ )
         {
+        wxPrintf( "D: TVectorEditor::showEnzymeGroups - appending '%s'\n" , vs[i] ) ;
         listGroups->Append ( vs[i] ) ;
         }
     showGroupEnzymes ( all ) ;
@@ -247,7 +268,7 @@ void TVectorEditor::enzymeAddEn ( wxCommandEvent &ev )
         if ( p == wxNOT_FOUND )
             {
             listCE->Append ( s ) ;
-            ce.Add ( s ) ;
+            TVectorEditor::ce.Add ( s ) ;
             }
         }
     wxPrintf( "D: TVectorEditor::enzymeAddEn - end\n" ) ;
@@ -264,7 +285,7 @@ void TVectorEditor::enzymeAddGr ( wxCommandEvent &ev )
         if ( b == wxNOT_FOUND )
            {
            listCE->Append ( s ) ;
-           ce.Add ( s ) ;
+           TVectorEditor::ce.Add ( s ) ;
            }
         }
     wxPrintf( "D: TVectorEditor::enzymeAddGr - end\n" ) ;
@@ -346,15 +367,15 @@ void TVectorEditor::enzymeDelEn ( wxCommandEvent &ev )
         listCE->Delete ( i ) ;
 
         int numDeleted = 0 ;
-        for ( int j = 0 ; j < ce.GetCount() ; j++ )
+        for ( int j = 0 ; j < TVectorEditor::ce.GetCount() ; j++ )
             {
-            if ( ce[i] == s )
+            if ( TVectorEditor::ce[i] == s )
                {
-               ce.RemoveAt ( j ) ;
+               TVectorEditor::ce.RemoveAt ( j ) ;
                numDeleted++ ;
                /*
-               ce[i] = ce[ce.size()-1] ;
-               ce.pop_back () ;
+               TVectorEditor::ce[i] = TVectorEditor::ce[TVectorEditor::ce.size()-1] ;
+               TVectorEditor::ce.pop_back () ;
                */
                }
             }


### PR DESCRIPTION
The "Current Enzymes" list was empty upon reopening the Enzyme Management window. The enzyme list is now static, so the information is preserved across multiple openings.

Also, many debug outputs were removed.