### PR TITLE
Changing OS for CI to Ubuntu (from MacOS with brew)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
TinyXML no longer supported.